### PR TITLE
Remove panels from EditPanel through config

### DIFF
--- a/src/js/components/field.js
+++ b/src/js/components/field.js
@@ -584,6 +584,12 @@ export default class Field {
     let editable = ['object', 'array'];
     let noPanels = ['config', 'meta', 'action'];
     let fieldData = formData.fields.get(_this.fieldID);
+
+    let disabledPanels = fieldData.meta.disabledPanels;
+    if (disabledPanels) {
+      noPanels = noPanels.concat(noPanels, disabledPanels);
+    }
+
     let allowedPanels = Object.keys(fieldData).filter(elem => {
         return !h.inArray(elem, noPanels);
       });


### PR DESCRIPTION
Similar to disableAttrs:[] in config object, disabledPanels:[] helps to hide/remove specified panels in EditPanel.
eg:
```
meta: {
          group: 'common',
          icon: 'select',
          id: 'select',
          disabledPanels: ['options']
     }
```
The above code will hide the Options in EditPanel for field.

Added the new property in meta{} as it is the object using for editor configurations.