### PR TITLE
Fixed: Label is close to previous input element.

### DIFF
--- a/src/sass/base/_bs.scss
+++ b/src/sass/base/_bs.scss
@@ -11,6 +11,7 @@ hr {
 
 .f-field-group {
   flex-wrap: wrap;
+  margin-top: 10px;
 
   label + .badge {
     margin-left: 10px;
@@ -18,7 +19,7 @@ hr {
 
   > label {
     display: inline-block;
-    margin-bottom: 10px;
+    margin-bottom: 3px;
   }
 
   button {


### PR DESCRIPTION
Fix for bug #132 .

Modified styles to add more space between a label and previous input element.

![after](https://user-images.githubusercontent.com/2847449/45957237-8cc47700-bfe2-11e8-97a5-1cd92ba6dc05.PNG)