### PR TITLE
Fixed the conditional logic for SELECT, RADIO and CHECKBOX

### DIFF
--- a/src/js/common/dom.js
+++ b/src/js/common/dom.js
@@ -395,7 +395,6 @@ class DOM {
     const { action, attrs } = elem
     const fieldType = attrs.type || elem.tag
     const id = attrs.id || elem.id
-    const multipleOptions = options.length > 1 && fieldType !== 'radio'
 
     const optionMap = (option, i) => {
       const { label, ...rest } = option
@@ -403,7 +402,7 @@ class DOM {
         const input = {
           tag: 'input',
           attrs: {
-            name: multipleOptions ? `${id}[]` : id,
+            name: id,
             type: fieldType,
             value: option.value || '',
             id: `${id}-${i}`,

--- a/src/js/components/controls/control.js
+++ b/src/js/components/controls/control.js
@@ -10,7 +10,6 @@ export default class Control {
   constructor({ events = {}, dependencies = {}, ...restConfig } = {}) {
     this.events = events
     this.controlData = restConfig
-    this.controlData.attrs = Object.assign({}, this.controlData.attrs, {hidden: false});
     this.depsLoaded = this.fetchDependencies(dependencies)
   }
 

--- a/src/js/components/controls/control.js
+++ b/src/js/components/controls/control.js
@@ -10,6 +10,7 @@ export default class Control {
   constructor({ events = {}, dependencies = {}, ...restConfig } = {}) {
     this.events = events
     this.controlData = restConfig
+    this.controlData.attrs = Object.assign({}, this.controlData.attrs, {hidden: false});
     this.depsLoaded = this.fetchDependencies(dependencies)
   }
 

--- a/src/js/components/controls/html/hr.js
+++ b/src/js/components/controls/html/hr.js
@@ -13,9 +13,6 @@ class HRControl extends Control {
         group: 'html',
         icon: 'divider',
         id: 'divider',
-      },
-      attrs: {
-        className: '',
       }
     }
     super(hrConfig)

--- a/src/js/components/controls/html/hr.js
+++ b/src/js/components/controls/html/hr.js
@@ -14,6 +14,9 @@ class HRControl extends Control {
         icon: 'divider',
         id: 'divider',
       },
+      attrs: {
+        className: '',
+      }
     }
     super(hrConfig)
   }


### PR DESCRIPTION
The fix addresses issues related to conditional evaluation for SELECT, RADIO & CHECKBOX elements. 

For SELECT fix, the tagName value is all caps as per https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName. 

For RADIO and CHECKBOX fix, there can be multiple elements in a group, hence they need to have a common group name.