### PR TITLE
fix: column drop position

### DIFF
--- a/src/demo/js/options/config.js
+++ b/src/demo/js/options/config.js
@@ -18,9 +18,10 @@ const config = {
       events: {
         onRender: element => {
           console.log(element)
-          setTimeout(() => {
+          const onRenderTimeout = setTimeout(() => {
             // formeo.Components.fields.get(element.id).toggleEdit(true)
             element.querySelector('.next-group').click()
+            clearTimeout(onRenderTimeout)
           }, 333)
         },
       },

--- a/src/js/common/dom.js
+++ b/src/js/common/dom.js
@@ -780,10 +780,6 @@ class DOM {
       document.dispatchEvent(events.columnResized)
     })
 
-    // fields.forEach(fieldId => Fields.get(fieldId).panelNav.refresh())
-
-    // setTimeout(() => fields.forEach(fieldId => Fields.get(fieldId).panelNav.refresh()), 250)
-
     dom.updateColumnPreset(row)
   }
 

--- a/src/js/components/component.js
+++ b/src/js/components/component.js
@@ -54,10 +54,7 @@ export default class Component extends Data {
         if (isInt(delItem)) {
           parent.splice(Number(delItem), 1)
         } else {
-          this.set(
-            delPath,
-            parent.filter(item => item !== delItem)
-          )
+          this.set(delPath, parent.filter(item => item !== delItem))
         }
       } else {
         delete parent[delItem]
@@ -321,12 +318,11 @@ export default class Component extends Data {
    * @param  {Object} evt
    * @return {Object} Component
    */
-  onAdd({ from, to, item }) {
+  onAdd({ from, to, item, newIndex }) {
     const _this = this
     if (!from.classList.contains(CONTROL_GROUP_CLASSNAME)) {
       from = from.parentElement
     }
-    const newIndex = indexOfNode(item, to)
     const fromType = componentType(from)
     const toType = componentType(to.parentElement)
     const defaultOnAdd = () => {
@@ -400,7 +396,7 @@ export default class Component extends Data {
           column: 1,
         }
         const action = (depthMap.get(targets[toType]) || identity)()
-        return action && action(item.id)
+        return action && action({ id: item.id }, newIndex)
       },
       column: () => {
         const targets = {

--- a/src/js/components/fields/edit-panel-item.js
+++ b/src/js/components/fields/edit-panel-item.js
@@ -230,29 +230,27 @@ export default class EditPanelItem {
     }
     const hideFields = fields => {
       fields = Array.isArray(fields) ? fields : [fields]
-      setTimeout(
-        () =>
-          fields.forEach(field => {
-            if (field.dom) {
-              field = field.dom
-            }
-            field.style.display = 'none'
-          }),
-        ANIMATION_SPEED_BASE
-      )
+      const hideFieldsTimeout = setTimeout(() => {
+        fields.forEach(field => {
+          if (field.dom) {
+            field = field.dom
+          }
+          field.style.display = 'none'
+        })
+        clearTimeout(hideFieldsTimeout)
+      }, ANIMATION_SPEED_BASE)
     }
     const showFields = fields => {
       fields = Array.isArray(fields) ? fields : [fields]
-      setTimeout(
-        () =>
-          fields.forEach(field => {
-            if (field.dom) {
-              field = field.dom
-            }
-            field.removeAttribute('style')
-          }),
-        ANIMATION_SPEED_BASE
-      )
+      const showFieldsTimeout = setTimeout(() => {
+        fields.forEach(field => {
+          if (field.dom) {
+            field = field.dom
+          }
+          field.removeAttribute('style')
+        })
+        clearTimeout(showFieldsTimeout)
+      }, ANIMATION_SPEED_BASE)
     }
     const actions = new Map([
       [

--- a/src/js/components/fields/field.js
+++ b/src/js/components/fields/field.js
@@ -158,7 +158,7 @@ export default class Field extends Component {
    * Updates the conditions panel when linked field data changes
    */
   updateConditionsPanel = () => {
-    setTimeout(() => {
+    const updateConditionsTimeout = setTimeout(() => {
       const newConditionsPanel = this.editPanels.find(({ name }) => name === 'conditions')
       if (!newConditionsPanel) {
         return null
@@ -166,6 +166,7 @@ export default class Field extends Component {
       const newProps = newConditionsPanel.createProps()
       const currentConditionsProps = this.dom.querySelector('.field-edit-conditions')
       currentConditionsProps.parentElement.replaceChild(newProps, currentConditionsProps)
+      clearTimeout(updateConditionsTimeout)
     }, ANIMATION_SPEED_BASE)
   }
 

--- a/src/js/components/rows/row.js
+++ b/src/js/components/rows/row.js
@@ -5,7 +5,7 @@ import dom from '../../common/dom'
 import events from '../../common/events'
 import { bsGridRegEx } from '../../common/helpers'
 import { numToPercent } from '../../common/utils'
-import { ROW_CLASSNAME, COLUMN_TEMPLATES, ANIMATION_SPEED_BASE, COLUMN_CLASSNAME } from '../../constants'
+import { ROW_CLASSNAME, COLUMN_TEMPLATES, ANIMATION_SPEED_FAST, COLUMN_CLASSNAME } from '../../constants'
 import { removeCustomOption } from '../columns/events'
 
 const DEFAULT_DATA = () =>
@@ -194,7 +194,10 @@ export default class Row extends Component {
       column.set('config.width', newColWidth)
       colDom.style.width = newColWidth
       colDom.dataset.colWidth = newColWidth
-      setTimeout(column.refreshFieldPanels, ANIMATION_SPEED_BASE)
+      const refreshTimeout = setTimeout(() => {
+        clearTimeout(refreshTimeout)
+        column.refreshFieldPanels()
+      }, ANIMATION_SPEED_FAST)
       document.dispatchEvent(events.columnResized)
     })
     this.updateColumnPreset()


### PR DESCRIPTION
BUG: columns are being appended to the end of a row no matter what index they are dropped at.
FIX: insert column at the correct index

current behavior
![before-column-drop-fix](https://user-images.githubusercontent.com/1457540/75646448-863a2600-5bfe-11ea-91b7-27a211f32996.gif)

corrected behavior
![after-column-drop-fix](https://user-images.githubusercontent.com/1457540/75646509-b41f6a80-5bfe-11ea-8452-536d1b48e3bb.gif)
