### PR TITLE
Feature/add checked condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ demo
 !src/demo
 dist
 yarn-error.log
+.idea
 .vscode
 .DS_Store
 .yarn.lock

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -150,6 +150,7 @@ export const CONDITION_INPUT_ORDER = [
 
 export const FIELD_PROPERTY_MAP = {
   value: 'attrs.value',
+  checked: 'attrs.checked',
   ...visiblityConfigs,
 }
 

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -217,9 +217,9 @@ export default class FormeoRenderer {
       notContains: (source, target) => !source.includes(target),
     }
 
-    const sourceValue = evt.target[sourceProperty]
-    const targetValue = isAddress(target) ? this.getComponent(target)[targetProperty] : target
-
+    // Compare as string, this allows values like "true" to be checked for properties like "checked".
+    const sourceValue = String(evt.target[sourceProperty])
+    const targetValue = String(isAddress(target) ? this.getComponent(target)[targetProperty] : target)
     return comparisonMap[comparison] && comparisonMap[comparison](sourceValue, targetValue)
   }
 

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -227,15 +227,29 @@ export default class FormeoRenderer {
     const assignMap = {
       equals: elem => {
         const propMap = {
-          value: () => (elem[targetProperty] = value),
-          isNotVisible: () => elem.parentElement.setAttribute('hidden', true),
-          isVisible: () => elem.parentElement.removeAttribute('hidden'),
+          value: () => {
+            elem[targetProperty] = value
+          },
+          isNotVisible: () => {
+            elem.parentElement.setAttribute('hidden', true)
+            elem.required = false // Hidden input cannot be required.
+          },
+          isVisible: () => {
+            elem.parentElement.removeAttribute('hidden')
+            elem.required = elem._required
+          },
         }
         propMap[targetProperty] && propMap[targetProperty]()
       },
     }
+
     if (isAddress(target)) {
       const elem = this.getComponent(target)
+
+      // Store required value.
+      if (elem && elem._required === undefined) {
+        elem._required = elem.required
+      }
       assignMap[assignment] && assignMap[assignment](elem)
     }
   }

--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -198,6 +198,11 @@ export default class FormeoRenderer {
                     false
                   )
                 }
+
+                // Evaluate conditions on load.
+                const fakeEvt = { target: component } // We don't have an actual event, mock one.
+                this.evaluateCondition(ifRest, fakeEvt) &&
+                  thenConditions.forEach(thenCondition => this.execResult(thenCondition, fakeEvt))
               })
             }
           })


### PR DESCRIPTION
While investigating Formeo, I needed to create a form which:

- contains a checkbox.
- contains a textfield.

Where:

- The textfield should be visible when the checkbox is checked.
- The textfield should be required when the checkbox is checked.
- The form should validate, with or without the checkbox being checked.

I ran into these issues:

- The conditionals would not let me specify the "checked" attribute.
- The conditionals would not let me compare (non string) attribute values.
- The conditionals could result in a required input which is hidden (which causes errors in browsers on submit).
- The conditionals would not trigger until the element was manipulated.

I resolved these issues with 3 different commits:

- 145a14b adds the "checked" option to the conditionals. It also changes the conditional evaluation by converting both the the source and target value to a string allowing booleans to be checked.
- f8374ff removes the required attribute on fields while they're hidden.
- 2518441 triggers evaluation of the conditionals when the form is rendered.
