### PR TITLE
Include sass source in build

### DIFF
--- a/src/sass/components/_stage.scss
+++ b/src/sass/components/_stage.scss
@@ -1,9 +1,9 @@
-@import 'components/group-actions';
-@import 'components/row';
-@import 'components/row-edit';
-@import 'components/column';
-@import 'components/field';
-@import 'components/field-edit';
+@import './group-actions';
+@import './row';
+@import './row-edit';
+@import './column';
+@import './field';
+@import './field-edit';
 
 .highlight-component {
   box-shadow: 0 0 space() 2px $brand-info;

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -28,6 +28,7 @@ const copyPatterns = [
     to: 'demo/assets/lang/',
     context: require.resolve('formeo-i18n').replace(/main.min.js$/, 'lang/'),
   },
+  { from: 'src/sass', to: 'dist/', context: projectRoot },
 ]
 
 const plugins = [


### PR DESCRIPTION
This enables projects that already use scss to import the source files into their builds and to customize the variables.

I did not update the README to mention this but can if you'd like

I also fixed a import issue that I hit when trying to import them.


After building the `dist` directory will contain:
```
dist
├── _render.scss
├── base
│   ├── _animation.scss
│   ├── _bs.scss
│   ├── _icons.scss
│   ├── _mixins.scss
│   ├── _rtl.scss
│   ├── _variables.scss
│   └── rtl
│       ├── _bs.scss
│       ├── _controls.scss
│       ├── _group-actions.scss
│       ├── _mixins.scss
│       ├── _row.scss
│       └── _stage.scss
├── components
│   ├── _autocomplete.scss
│   ├── _column.scss
│   ├── _controls.scss
│   ├── _field-edit.scss
│   ├── _field.scss
│   ├── _group-actions.scss
│   ├── _panels.scss
│   ├── _row-edit.scss
│   ├── _row.scss
│   ├── _stage.scss
│   └── component.scss
├── formeo.min.css
├── formeo.min.js
├── formeo.min.js.gz
└── formeo.scss
```