### PR TITLE
feat(layout): add controlOnLeft option

### DIFF
--- a/src/demo/js/options/index.js
+++ b/src/demo/js/options/index.js
@@ -27,6 +27,7 @@ export const editorOptions = {
   // debug: true,
   sessionStorage: true,
   editPanelOrder: ['attrs', 'options'],
+  // controlOnLeft: true,
 }
 
 export const renderOptions = {

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -120,6 +120,11 @@ export class FormeoEditor {
    */
   render() {
     this.stages = Object.values(Components.get('stages'))
+    if (this.opts.controlOnLeft) {
+      this.stages.forEach(stage => {
+        stage.dom.style.order = 1
+      })
+    }
     const elemConfig = {
       attrs: {
         className: 'formeo formeo-editor',


### PR DESCRIPTION
Hello,

This is small feature improvement where user can choose to have control on the left side using controlOnLeft: true when initiating form editor.

![image](https://github.com/Draggable/formeo/assets/5115956/e6fa0ca0-a773-4967-9f68-82a2b8b023a1)
