### PR TITLE
fix: control cloning

### DIFF
--- a/src/lib/js/common/utils/index.mjs
+++ b/src/lib/js/common/utils/index.mjs
@@ -111,9 +111,9 @@ export const merge = (obj1, obj2, opts = Object.create(null)) => {
     if (Array.isArray(objValue)) {
       if (Array.isArray(srcValue)) {
         return unique(opts.mergeArray ? objValue.concat(srcValue) : srcValue)
-      } else {
-        return srcValue
       }
+
+      return srcValue
     }
   }
   return mergeWith({}, obj1, obj2, customizer)
@@ -138,7 +138,7 @@ export const clone = obj => {
   }
 
   // Handle Array
-  if (obj instanceof Array) {
+  if (Array.isArray(obj)) {
     copy = []
     for (let i = 0, len = obj.length; i < len; i++) {
       copy[i] = clone(obj[i])
@@ -150,7 +150,7 @@ export const clone = obj => {
   if (obj instanceof Object) {
     copy = {}
     for (const attr in obj) {
-      if (obj.hasOwnProperty(attr)) {
+      if (Object.hasOwn(obj, attr)) {
         copy[attr] = clone(obj[attr])
       }
     }
@@ -163,7 +163,7 @@ export const clone = obj => {
 
 export const percent = (val, total) => (val / total) * 100
 
-export const numToPercent = num => num.toString() + '%'
+export const numToPercent = num => `${num.toString()}%`
 
 export const numberBetween = (num, min, max) => num > min && num < max
 

--- a/src/lib/js/components/controls/index.js
+++ b/src/lib/js/components/controls/index.js
@@ -48,16 +48,6 @@ export class Controls {
   }
 
   /**
-   * Dragging from the control bar clears element
-   * events lets add them back after drag.
-   * @param  {Object} evt
-   */
-  applyControlEvents = ({ clone: control }) => {
-    const button = control.querySelector('button')
-    Object.keys(this.controlEvents).map(action => button.addEventListener(action, this.controlEvents[action]))
-  }
-
-  /**
    * Generate control config for UI and bind actions
    * @return {Array} elementControls
    */
@@ -171,7 +161,6 @@ export class Controls {
   }
 
   get(controlId) {
-    // return clone(this.data.get(controlId))
     return this.data.get(controlId)
   }
 
@@ -259,13 +248,13 @@ export class Controls {
       content: [this.panels.panelNav, this.panels.panelsWrap],
     })
 
-    let controlClass = 'formeo-controls'
+    const controlClasses = ['formeo-controls']
     if (sticky) {
-      controlClass += ' formeo-sticky'
+      controlClasses.push('formeo-sticky')
     }
 
     const element = dom.create({
-      className: controlClass,
+      className: controlClasses,
       content: [groupsWrap, formActions],
     })
     const groups = element.getElementsByClassName('control-group')
@@ -324,12 +313,16 @@ export class Controls {
           pull: 'clone',
           put: false,
         },
-        onRemove: this.applyControlEvents,
         onStart: ({ item }) => {
           const { controlData } = this.get(item.id)
           if (this.options.ghostPreview) {
             item.innerHTML = ''
             item.appendChild(new Field(controlData).preview)
+          }
+        },
+        onEnd: ({ from, item, clone }) => {
+          if (from.contains(clone)) {
+            from.replaceChild(item, clone)
           }
         },
         sort: this.options.sortable,

--- a/src/lib/js/components/fields/field.js
+++ b/src/lib/js/components/fields/field.js
@@ -78,11 +78,10 @@ export default class Field extends Component {
         config.tag = 'input'
         config.attrs.value = labelVal
         return config
-      } else {
-        config.attrs.contenteditable = true
-        config.children = labelVal
-        return config
       }
+      config.attrs.contenteditable = true
+      config.children = labelVal
+      return config
     }
 
     const label = {
@@ -118,14 +117,14 @@ export default class Field extends Component {
       return null
     }
 
-    newConditionsPanel.editPanelItems.forEach(({ itemFieldGroups }) => {
-      itemFieldGroups.forEach(fields => {
+    for (const { itemFieldGroups } of newConditionsPanel.editPanelItems) {
+      for (const fields of itemFieldGroups) {
         const autocomplete = fields.find(field => field.value === value)
         if (autocomplete) {
           autocomplete.displayField.value = label
         }
-      })
-    })
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
controls were not cloned correctly since the sortable update. they were missing their id which is a bug introduced with this update: https://github.com/vanboom/Sortable/commit/840f9aef8452e2944e6984d49965bcc86ed96863

onEnd will now replace the cloned control with the original that was removed. this also negates the need to re-add the event listeners.