### PR TITLE
fix: wire up generic onAdd and onRemove event callbacks (issue #160)

### DIFF
--- a/src/lib/js/common/events.js
+++ b/src/lib/js/common/events.js
@@ -33,6 +33,7 @@ const defaults = {
   bubbles: true, // bubble events from components
   formeoLoaded: _evt => {},
   onAdd: () => {},
+  onRemove: () => {},
   onChange: evt => events.opts?.debug && console.log(evt),
   onUpdate: evt => events.opts?.debug && console.log(evt),
   onUpdateStage: evt => events.opts?.debug && console.log(evt),
@@ -136,36 +137,42 @@ document.addEventListener(EVENT_FORMEO_UPDATED_FIELD, evt => {
 document.addEventListener(EVENT_FORMEO_ADDED_ROW, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onAdd(eventData)
   events.opts.onAddRow(eventData)
 })
 
 document.addEventListener(EVENT_FORMEO_ADDED_COLUMN, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onAdd(eventData)
   events.opts.onAddColumn(eventData)
 })
 
 document.addEventListener(EVENT_FORMEO_ADDED_FIELD, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onAdd(eventData)
   events.opts.onAddField(eventData)
 })
 
 document.addEventListener(EVENT_FORMEO_REMOVED_ROW, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onRemove(eventData)
   events.opts.onRemoveRow(eventData)
 })
 
 document.addEventListener(EVENT_FORMEO_REMOVED_COLUMN, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onRemove(eventData)
   events.opts.onRemoveColumn(eventData)
 })
 
 document.addEventListener(EVENT_FORMEO_REMOVED_FIELD, evt => {
   const { timeStamp, type, detail } = evt
   const eventData = { timeStamp, type, detail }
+  events.opts.onRemove(eventData)
   events.opts.onRemoveField(eventData)
 })
 

--- a/src/lib/js/common/events.test.js
+++ b/src/lib/js/common/events.test.js
@@ -467,6 +467,65 @@ describe('Events System', () => {
         Events.formeoAddedField({ componentId: 'field-test' })
       })
     })
+
+    it('should call generic onAdd callback for row additions', () => {
+      return new Promise(resolve => {
+        const onAdd = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_ADDED_ROW)
+          resolve()
+        })
+
+        Events.init({ onAdd })
+
+        Events.formeoAddedRow({ componentId: 'row-test' })
+      })
+    })
+
+    it('should call generic onAdd callback for column additions', () => {
+      return new Promise(resolve => {
+        const onAdd = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_ADDED_COLUMN)
+          resolve()
+        })
+
+        Events.init({ onAdd })
+
+        Events.formeoAddedColumn({ componentId: 'column-test' })
+      })
+    })
+
+    it('should call generic onAdd callback for field additions', () => {
+      return new Promise(resolve => {
+        const onAdd = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_ADDED_FIELD)
+          resolve()
+        })
+
+        Events.init({ onAdd })
+
+        Events.formeoAddedField({ componentId: 'field-test' })
+      })
+    })
+
+    it('should call both generic onAdd and specific onAddRow callbacks', () => {
+      return new Promise(resolve => {
+        let calls = 0
+        const onAdd = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_ADDED_ROW)
+          calls++
+          if (calls === 2) resolve()
+        })
+        const onAddRow = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_ADDED_ROW)
+          calls++
+          if (calls === 2) resolve()
+        })
+
+        Events.init({ onAdd, onAddRow })
+
+        Events.formeoAddedRow({ componentId: 'row-test' })
+      })
+    })
   })
 
   describe('Remove events', () => {
@@ -548,6 +607,65 @@ describe('Events System', () => {
         Events.init({ onRemoveField })
 
         Events.formeoRemovedField({ componentId: 'field-test' })
+      })
+    })
+
+    it('should call generic onRemove callback for row removals', () => {
+      return new Promise(resolve => {
+        const onRemove = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_REMOVED_ROW)
+          resolve()
+        })
+
+        Events.init({ onRemove })
+
+        Events.formeoRemovedRow({ componentId: 'row-test' })
+      })
+    })
+
+    it('should call generic onRemove callback for column removals', () => {
+      return new Promise(resolve => {
+        const onRemove = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_REMOVED_COLUMN)
+          resolve()
+        })
+
+        Events.init({ onRemove })
+
+        Events.formeoRemovedColumn({ componentId: 'column-test' })
+      })
+    })
+
+    it('should call generic onRemove callback for field removals', () => {
+      return new Promise(resolve => {
+        const onRemove = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_REMOVED_FIELD)
+          resolve()
+        })
+
+        Events.init({ onRemove })
+
+        Events.formeoRemovedField({ componentId: 'field-test' })
+      })
+    })
+
+    it('should call both generic onRemove and specific onRemoveRow callbacks', () => {
+      return new Promise(resolve => {
+        let calls = 0
+        const onRemove = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_REMOVED_ROW)
+          calls++
+          if (calls === 2) resolve()
+        })
+        const onRemoveRow = mock.fn(evt => {
+          assert.equal(evt.type, EVENT_FORMEO_REMOVED_ROW)
+          calls++
+          if (calls === 2) resolve()
+        })
+
+        Events.init({ onRemove, onRemoveRow })
+
+        Events.formeoRemovedRow({ componentId: 'row-test' })
       })
     })
   })


### PR DESCRIPTION
## Problem

The `onAdd` callback was defined in `events.js` defaults (line 35) but was **never actually invoked**. Users who configured `onAdd` in their events config would never see it fire when components were added to the form builder.

Reported in [issue #160](https://github.com/Draggable/formeo/issues/160) (Nov 2018).

## Solution

Wire up `onAdd` to fire alongside the specific add callbacks (`onAddRow`, `onAddColumn`, `onAddField`) — following the same pattern already used by `onUpdate` which fires alongside `onUpdateStage/Row/Column/Field`.

Additionally, added `onRemove` to defaults and wired it alongside `onRemoveRow/Column/Field` for symmetry.

## Changes

- **src/lib/js/common/events.js**:
  - Added `onRemove` to defaults
  - Added `events.opts.onAdd(eventData)` calls in the 3 add event listeners
  - Added `events.opts.onRemove(eventData)` calls in the 3 remove event listeners

- **src/lib/js/common/events.test.js**:
  - Added 4 tests for generic `onAdd` callback (row/column/field + combined)
  - Added 4 tests for generic `onRemove` callback (row/column/field + combined)

## Usage

After this fix, users can use `onAdd` as originally intended:

```js
events: {
  onAdd: (evt) => {
    // Fires whenever ANY component is added (row, column, or field)
    console.log('Component added:', evt.detail)
  },
  onRemove: (evt) => {
    // Fires whenever ANY component is removed (row, column, or field)
    console.log('Component removed:', evt.detail)
  },
}
```

## Testing

- All 162 tests pass (154 existing + 8 new)
- Lint passes (Biome)