### PR TITLE
chore: configure dependabot to group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Group all npm dependency updates into a single daily PR
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  # Group all GitHub Actions updates into a single weekly PR
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

Dependabot PRs arrive one at a time per package, creating PR noise and merge overhead.

## Solution

Added `.github/dependabot.yml` with grouped updates:

- **npm dependencies** (both `dependencies` and `devDependencies`): grouped into **one PR per day**
- **GitHub Actions**: grouped into **one PR per week** (Mondays)

## Details

- Uses `open-pull-requests-limit: 1` per ecosystem to cap queue depth
- Schedule set to 6:00 AM Central (America/Chicago timezone)
- All packages matched via `patterns: ["*"]` in a single group
