### PR TITLE
Add request timeout handling and reduce CI test retries

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/src/lib/js/common/loaders.js
+++ b/src/lib/js/common/loaders.js
@@ -8,16 +8,20 @@ export const loaded = {
   formeoSprite: null,
 }
 
-export const ajax = (fileUrl, callback, onError = noop) => {
+export const AJAX_TIMEOUT_MS = 10000
+
+export const ajax = (fileUrl, callback, onError = noop, timeoutMs = AJAX_TIMEOUT_MS) => {
   return new Promise(resolve => {
-    return fetch(fileUrl)
+    const signal =
+      typeof AbortSignal !== 'undefined' && AbortSignal.timeout ? AbortSignal.timeout(timeoutMs) : undefined
+    return fetch(fileUrl, signal ? { signal } : undefined)
       .then(data => {
         if (!data.ok) {
           return resolve(onError(data))
         }
         resolve(callback ? callback(data) : data)
       })
-      .catch(err => onError(err))
+      .catch(err => resolve(onError(err)))
   })
 }
 


### PR DESCRIPTION
## Summary
This PR improves the robustness of AJAX requests by adding configurable timeout support and reduces unnecessary test retries in CI environments.

## Key Changes
- **AJAX timeout support**: Added `AJAX_TIMEOUT_MS` constant (10 seconds default) and a `timeoutMs` parameter to the `ajax()` function. Uses the native `AbortSignal.timeout()` API when available for automatic request cancellation.
- **Error handling fix**: Changed `.catch()` to resolve with `onError()` result instead of rejecting, ensuring consistent error handling behavior.
- **CI test retries**: Reduced Playwright test retries from 2 to 1 on CI to speed up feedback loops while maintaining reasonable reliability.

## Implementation Details
- The timeout implementation gracefully degrades: if `AbortSignal.timeout()` is not available (older environments), the signal is undefined and fetch proceeds without timeout.
- The error handling change ensures that network errors are properly caught and passed to the error callback, with the promise always resolving rather than rejecting.

https://claude.ai/code/session_012w1wEVswQvBsQPEeaXwZvW