### PR TITLE
fix: support multiple FormeoEditor instances on same page (#152)

### DIFF
--- a/src/lib/js/common/actions.js
+++ b/src/lib/js/common/actions.js
@@ -1,11 +1,6 @@
 import i18n from '@draggable/i18n'
 import { CONDITION_TEMPLATE, SESSION_FORMDATA_KEY } from '../constants.js'
-import events from './events.js'
 import { identity, sessionStorage } from './utils/index.mjs'
-
-// Actions are the callbacks for things like adding
-// new attributes, options, field removal confirmations etc.
-// Every Action below can be overridden via module options
 
 // Default options
 const defaultActions = {
@@ -14,7 +9,7 @@ const defaultActions = {
       const attr = globalThis.prompt(evt.message.attr)
       if (attr && evt.isDisabled(attr)) {
         globalThis.alert(i18n.get('attributeNotPermitted', attr))
-        return actions.add.attrs(evt)
+        return this.add.attrs(evt)
       }
       let val
       if (attr) {
@@ -54,58 +49,81 @@ const defaultActions = {
 }
 
 /**
- * @todo refactor to handle multiple instances of formeo
+ * Actions class handles user actions (add, remove, clone, edit components).
+ * Each FormeoEditor instance creates its own Actions object so that
+ * multiple editors on the same page don't share action state.
  */
-const actions = {
-  init: function (options) {
+export class Actions {
+  /** @type {Object} */
+  opts = null
+
+  /** @type {Events} */
+  events = null
+
+  /**
+   * @param {Events} events - The Events instance for dispatching events
+   */
+  constructor(events) {
+    this.events = events
+  }
+
+  init(options = {}) {
     const actionKeys = Object.keys(defaultActions)
     this.opts = actionKeys.reduce((acc, key) => {
       acc[key] = { ...defaultActions[key], ...options[key] }
       return acc
     }, options)
     return this
-  },
-  add: {
+  }
+
+  add = {
     attrs: evt => {
-      return actions.opts.add.attr(evt)
+      return this.opts.add.attr(evt)
     },
     options: evt => {
-      return actions.opts.add.option(evt)
+      return this.opts.add.option(evt)
     },
     conditions: evt => {
       evt.template = evt.template || CONDITION_TEMPLATE()
-      return actions.opts.add.condition(evt)
+      return this.opts.add.condition(evt)
     },
     config: evt => {
-      return actions.opts.add.config(evt)
+      return this.opts.add.config(evt)
     },
-  },
-  remove: {
+  }
+
+  remove = {
     attrs: evt => {
-      return actions.opts.remove.attrs(evt)
+      return this.opts.remove.attrs(evt)
     },
     options: evt => {
-      return actions.opts.remove.options(evt)
+      return this.opts.remove.options(evt)
     },
     conditions: evt => {
-      return actions.opts.remove.conditions(evt)
+      return this.opts.remove.conditions(evt)
     },
-  },
-  click: {
+  }
+
+  click = {
     btn: evt => {
-      return actions.opts.click.btn(evt)
+      return this.opts.click.btn(evt)
     },
-  },
-  save: {
+  }
+
+  save = {
     form: formData => {
-      if (actions.opts.sessionStorage) {
+      if (this.opts.sessionStorage) {
         sessionStorage.set(SESSION_FORMDATA_KEY, formData)
       }
-
-      events.formeoSaved({ formData })
-      return actions.opts.save.form(formData)
+      this.events.formeoSaved({ formData })
+      return this.opts.save.form(formData)
     },
-  },
+  }
 }
+
+// Singleton instance for backward compatibility
+// Note: this singleton uses a placeholder events reference
+// that will be replaced when the editor creates its own Actions instance
+const actions = new Actions(null)
 
 export default actions

--- a/src/lib/js/common/actions.js
+++ b/src/lib/js/common/actions.js
@@ -1,22 +1,25 @@
 import i18n from '@draggable/i18n'
 import { CONDITION_TEMPLATE, SESSION_FORMDATA_KEY } from '../constants.js'
+import events from './events.js'
 import { identity, sessionStorage } from './utils/index.mjs'
 
 // Default options
+const addAttributeAction = evt => {
+  const attr = globalThis.prompt(evt.message.attr)
+  if (attr && evt.isDisabled(attr)) {
+    globalThis.alert(i18n.get('attributeNotPermitted', attr))
+    return addAttributeAction(evt)
+  }
+  let val
+  if (attr) {
+    val = String(globalThis.prompt(evt.message.value, ''))
+    evt.addAction(attr, val)
+  }
+}
+
 const defaultActions = {
   add: {
-    attr: evt => {
-      const attr = globalThis.prompt(evt.message.attr)
-      if (attr && evt.isDisabled(attr)) {
-        globalThis.alert(i18n.get('attributeNotPermitted', attr))
-        return this.add.attrs(evt)
-      }
-      let val
-      if (attr) {
-        val = String(globalThis.prompt(evt.message.value, ''))
-        evt.addAction(attr, val)
-      }
-    },
+    attr: addAttributeAction,
     option: evt => {
       evt.addAction()
     },
@@ -115,15 +118,13 @@ export class Actions {
       if (this.opts.sessionStorage) {
         sessionStorage.set(SESSION_FORMDATA_KEY, formData)
       }
-      this.events.formeoSaved({ formData })
+      this.events?.formeoSaved({ formData })
       return this.opts.save.form(formData)
     },
   }
 }
 
 // Singleton instance for backward compatibility
-// Note: this singleton uses a placeholder events reference
-// that will be replaced when the editor creates its own Actions instance
-const actions = new Actions(null)
+const actions = new Actions(events)
 
 export default actions

--- a/src/lib/js/common/events.js
+++ b/src/lib/js/common/events.js
@@ -1,4 +1,3 @@
-import components, { Columns, Controls } from '../components/index.js'
 import {
   ANIMATION_SPEED_BASE,
   ANIMATION_SPEED_FAST,
@@ -23,207 +22,398 @@ import { throttle } from './utils/index.mjs'
 
 const NO_TRANSITION_CLASS_NAME = 'no-transition'
 
-// @todo
-// Refactor events as part of https://github.com/Draggable/formeo/issues/381
-// should have a consolidated approach to events
-
-// Default options
-const defaults = {
-  debug: false, // enable debug mode
-  bubbles: true, // bubble events from components
-  formeoLoaded: _evt => {},
-  onAdd: () => {},
-  onChange: evt => events.opts?.debug && console.log(evt),
-  onUpdate: evt => events.opts?.debug && console.log(evt),
-  onUpdateStage: evt => events.opts?.debug && console.log(evt),
-  onUpdateRow: evt => events.opts?.debug && console.log(evt),
-  onUpdateColumn: evt => events.opts?.debug && console.log(evt),
-  onUpdateField: evt => events.opts?.debug && console.log(evt),
-  onAddRow: evt => events.opts?.debug && console.log(evt),
-  onAddColumn: evt => events.opts?.debug && console.log(evt),
-  onAddField: evt => events.opts?.debug && console.log(evt),
-  onRemoveRow: evt => events.opts?.debug && console.log(evt),
-  onRemoveColumn: evt => events.opts?.debug && console.log(evt),
-  onRemoveField: evt => events.opts?.debug && console.log(evt),
-  onRender: evt => events.opts?.debug && console.log(evt),
-  onSave: _evt => {},
-  confirmClearAll: evt => {
-    if (globalThis.confirm(evt.confirmationMessage)) {
-      evt.clearAllAction(evt)
-    }
-  },
-}
-
-const defaultCustomEvent = ({ src, ...evtData }, type = EVENT_FORMEO_UPDATED) => {
-  const evt = new globalThis.CustomEvent(type, {
-    detail: evtData,
-    bubbles: events.opts?.debug || events.opts?.bubbles,
-  })
-  evt.data = (src || document).dispatchEvent(evt)
-
-  // Also dispatch formeoChanged as an alias for formeoUpdated
-  if (type === EVENT_FORMEO_UPDATED) {
-    const changedEvt = new globalThis.CustomEvent(EVENT_FORMEO_CHANGED, {
-      detail: evtData,
-      bubbles: events.opts?.debug || events.opts?.bubbles,
-    })
-    ;(src || document).dispatchEvent(changedEvt)
+/**
+ * Creates default callback handlers for events.
+ * @param {Events} self - reference to the Events instance for accessing opts
+ * @return {Object} default callbacks
+ */
+function createDefaults(self) {
+  return {
+    debug: false,
+    bubbles: true,
+    formeoLoaded: _evt => {},
+    onAdd: () => {},
+    onChange: evt => self.opts?.debug && console.log(evt),
+    onUpdate: evt => self.opts?.debug && console.log(evt),
+    onUpdateStage: evt => self.opts?.debug && console.log(evt),
+    onUpdateRow: evt => self.opts?.debug && console.log(evt),
+    onUpdateColumn: evt => self.opts?.debug && console.log(evt),
+    onUpdateField: evt => self.opts?.debug && console.log(evt),
+    onAddRow: evt => self.opts?.debug && console.log(evt),
+    onAddColumn: evt => self.opts?.debug && console.log(evt),
+    onAddField: evt => self.opts?.debug && console.log(evt),
+    onRemoveRow: evt => self.opts?.debug && console.log(evt),
+    onRemoveColumn: evt => self.opts?.debug && console.log(evt),
+    onRemoveField: evt => self.opts?.debug && console.log(evt),
+    onRender: evt => self.opts?.debug && console.log(evt),
+    onSave: _evt => {},
+    confirmClearAll: evt => {
+      if (globalThis.confirm(evt.confirmationMessage)) {
+        evt.clearAllAction(evt)
+      }
+    },
   }
-
-  return evt
 }
 
 /**
- * Events class is used to register events and throttle their callbacks
+ * Events class is used to register events and throttle their callbacks.
+ * Each FormeoEditor instance creates its own Events object so that
+ * multiple editors on the same page don't share event state.
  */
-const events = {
-  init: function (options) {
-    this.opts = { ...defaults, ...options }
-    return this
-  },
-  formeoSaved: evt => defaultCustomEvent(evt, EVENT_FORMEO_SAVED),
-  formeoUpdated: (evt, eventType) => defaultCustomEvent(evt, eventType || EVENT_FORMEO_UPDATED),
-  formeoCleared: evt => defaultCustomEvent(evt, EVENT_FORMEO_CLEARED),
-  formeoOnRender: evt => defaultCustomEvent(evt, EVENT_FORMEO_ON_RENDER),
-  formeoConditionUpdated: evt => defaultCustomEvent(evt, EVENT_FORMEO_CONDITION_UPDATED),
-  formeoAddedRow: evt => defaultCustomEvent(evt, EVENT_FORMEO_ADDED_ROW),
-  formeoAddedColumn: evt => defaultCustomEvent(evt, EVENT_FORMEO_ADDED_COLUMN),
-  formeoAddedField: evt => defaultCustomEvent(evt, EVENT_FORMEO_ADDED_FIELD),
-  formeoRemovedRow: evt => defaultCustomEvent(evt, EVENT_FORMEO_REMOVED_ROW),
-  formeoRemovedColumn: evt => defaultCustomEvent(evt, EVENT_FORMEO_REMOVED_COLUMN),
-  formeoRemovedField: evt => defaultCustomEvent(evt, EVENT_FORMEO_REMOVED_FIELD),
-}
+export class Events {
+  /** @type {Object} */
+  opts = null
 
-const formeoUpdatedThrottled = throttle(() => {
-  const eventData = {
-    timeStamp: globalThis.performance.now(),
-    type: EVENT_FORMEO_UPDATED,
-    detail: components.formData,
-  }
-  events.opts.onUpdate(eventData)
-  // Also call onChange if it's different from onUpdate
-  if (events.opts.onChange !== events.opts.onUpdate) {
-    events.opts.onChange(eventData)
-  }
-}, ANIMATION_SPEED_FAST)
-
-document.addEventListener(EVENT_FORMEO_UPDATED, formeoUpdatedThrottled)
-document.addEventListener(EVENT_FORMEO_UPDATED_STAGE, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onUpdate(eventData)
-  events.opts.onUpdateStage(eventData)
-})
-document.addEventListener(EVENT_FORMEO_UPDATED_ROW, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onUpdate(eventData)
-  events.opts.onUpdateRow(eventData)
-})
-document.addEventListener(EVENT_FORMEO_UPDATED_COLUMN, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onUpdate(eventData)
-  events.opts.onUpdateColumn(eventData)
-})
-document.addEventListener(EVENT_FORMEO_UPDATED_FIELD, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onUpdate(eventData)
-  events.opts.onUpdateField(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_ADDED_ROW, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onAddRow(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_ADDED_COLUMN, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onAddColumn(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_ADDED_FIELD, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onAddField(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_REMOVED_ROW, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onRemoveRow(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_REMOVED_COLUMN, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onRemoveColumn(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_REMOVED_FIELD, evt => {
-  const { timeStamp, type, detail } = evt
-  const eventData = { timeStamp, type, detail }
-  events.opts.onRemoveField(eventData)
-})
-
-document.addEventListener(EVENT_FORMEO_ON_RENDER, evt => {
-  const { timeStamp, type, detail } = evt
-  events.opts.onRender({
-    timeStamp,
-    type,
-    detail,
-  })
-})
-
-document.addEventListener('confirmClearAll', evt => {
-  evt = {
-    timeStamp: evt.timeStamp,
-    type: evt.type,
-    confirmationMessage: evt.detail.confirmationMessage,
-    clearAllAction: evt.detail.clearAllAction,
-    btnCoords: evt.detail.btnCoords,
+  /**
+   * @param {Element} [container=document] - DOM element to dispatch events on
+   */
+  constructor(container = document) {
+    this.container = container
+    this._listeners = []
   }
 
-  events.opts.confirmClearAll(evt)
-})
+  init(options = {}) {
+    this.opts = { ...createDefaults(this), ...options }
 
-document.addEventListener(EVENT_FORMEO_SAVED, ({ timeStamp, type, detail: { formData } }) => {
-  const evt = {
-    timeStamp,
-    type,
-    formData,
-  }
-  events.opts.onSave(evt)
-})
-
-document.addEventListener('formeoLoaded', evt => {
-  events.opts.formeoLoaded(evt.detail.formeo)
-})
-
-let throttling
-
-function onResizeWindow() {
-  throttling =
-    throttling ||
-    window.requestAnimationFrame(() => {
-      throttling = false
-      for (const column of Object.values(Columns.data)) {
-        column.dom.classList.add(NO_TRANSITION_CLASS_NAME)
-        Controls.dom.classList.add(NO_TRANSITION_CLASS_NAME)
-        Controls.panels.nav.refresh()
-        column.refreshFieldPanels()
-        throttle(() => {
-          column.dom.classList.remove(NO_TRANSITION_CLASS_NAME)
-          Controls.dom.classList.remove(NO_TRANSITION_CLASS_NAME)
-        }, ANIMATION_SPEED_BASE)
+    // Auto-register listeners for the singleton (backward compatibility with tests)
+    // Per-instance Events objects should call registerListeners() explicitly
+    if (this === events) {
+      this._autoRegistered = true
+      for (const { event, handler } of this._getBasicListeners()) {
+        this.container.addEventListener(event, handler)
+        this._listeners.push({ event, handler })
       }
+    }
+
+    return this
+  }
+
+  /**
+   * Get basic event listeners (those that don't require components/columns/controls).
+   * @return {Array} listener objects
+   */
+  _getBasicListeners() {
+    return [
+      {
+        event: EVENT_FORMEO_UPDATED_STAGE,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateStage(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_ROW,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateRow(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_COLUMN,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateColumn(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_FIELD,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateField(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_ROW,
+        handler: evt => {
+          this.opts.onAddRow({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_COLUMN,
+        handler: evt => {
+          this.opts.onAddColumn({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_FIELD,
+        handler: evt => {
+          this.opts.onAddField({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_ROW,
+        handler: evt => {
+          this.opts.onRemoveRow({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_COLUMN,
+        handler: evt => {
+          this.opts.onRemoveColumn({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_FIELD,
+        handler: evt => {
+          this.opts.onRemoveField({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ON_RENDER,
+        handler: evt => {
+          this.opts.onRender({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_SAVED,
+        handler: ({ timeStamp, type, detail: { formData } }) => {
+          this.opts.onSave({ timeStamp, type, formData })
+        },
+      },
+      {
+        event: 'formeoLoaded',
+        handler: evt => {
+          this.opts.formeoLoaded(evt.detail.formeo)
+        },
+      },
+    ]
+  }
+
+  /**
+   * Create and dispatch a CustomEvent on this editor's container.
+   */
+  dispatchCustomEvent(evtData, type) {
+    const { src, ...detail } = evtData
+    const evt = new globalThis.CustomEvent(type, {
+      detail,
+      bubbles: this.opts?.debug || this.opts?.bubbles,
     })
+    evt.data = (src || this.container).dispatchEvent(evt)
+    return evt
+  }
+
+  formeoSaved(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_SAVED)
+  }
+
+  formeoUpdated(evtData, type = EVENT_FORMEO_UPDATED) {
+    const result = this.dispatchCustomEvent(evtData, type)
+    // Also dispatch formeoChanged as an alias for formeoUpdated
+    if (type === EVENT_FORMEO_UPDATED) {
+      const { src, ...detail } = evtData
+      const changedEvt = new globalThis.CustomEvent(EVENT_FORMEO_CHANGED, {
+        detail,
+        bubbles: this.opts?.debug || this.opts?.bubbles,
+      })
+      ;(src || this.container).dispatchEvent(changedEvt)
+    }
+    return result
+  }
+
+  formeoCleared(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_CLEARED)
+  }
+
+  formeoOnRender(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_ON_RENDER)
+  }
+
+  formeoConditionUpdated(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_CONDITION_UPDATED)
+  }
+
+  formeoAddedRow(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_ADDED_ROW)
+  }
+
+  formeoAddedColumn(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_ADDED_COLUMN)
+  }
+
+  formeoAddedField(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_ADDED_FIELD)
+  }
+
+  formeoRemovedRow(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_REMOVED_ROW)
+  }
+
+  formeoRemovedColumn(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_REMOVED_COLUMN)
+  }
+
+  formeoRemovedField(evtData) {
+    return this.dispatchCustomEvent(evtData, EVENT_FORMEO_REMOVED_FIELD)
+  }
+
+  /**
+   * Register DOM event listeners for this editor instance.
+   * @param {Object} components - The Components instance for formData access
+   * @param {Object} columns - The Columns data store for resize handling
+   * @param {Object} controls - The Controls instance for resize handling
+   */
+  registerListeners(components, columns, controls) {
+    // Throttled formeoUpdated handler
+    const formeoUpdatedThrottled = throttle(() => {
+      const eventData = {
+        timeStamp: globalThis.performance.now(),
+        type: EVENT_FORMEO_UPDATED,
+        detail: components.formData,
+      }
+      this.opts.onUpdate(eventData)
+      if (this.opts.onChange !== this.opts.onUpdate) {
+        this.opts.onChange(eventData)
+      }
+    }, ANIMATION_SPEED_FAST)
+
+    const listeners = [
+      { event: EVENT_FORMEO_UPDATED, handler: formeoUpdatedThrottled },
+      {
+        event: EVENT_FORMEO_UPDATED_STAGE,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateStage(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_ROW,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateRow(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_COLUMN,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateColumn(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_UPDATED_FIELD,
+        handler: evt => {
+          const eventData = { timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail }
+          this.opts.onUpdate(eventData)
+          this.opts.onUpdateField(eventData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_ROW,
+        handler: evt => {
+          this.opts.onAddRow({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_COLUMN,
+        handler: evt => {
+          this.opts.onAddColumn({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ADDED_FIELD,
+        handler: evt => {
+          this.opts.onAddField({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_ROW,
+        handler: evt => {
+          this.opts.onRemoveRow({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_COLUMN,
+        handler: evt => {
+          this.opts.onRemoveColumn({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_REMOVED_FIELD,
+        handler: evt => {
+          this.opts.onRemoveField({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: EVENT_FORMEO_ON_RENDER,
+        handler: evt => {
+          this.opts.onRender({ timeStamp: evt.timeStamp, type: evt.type, detail: evt.detail })
+        },
+      },
+      {
+        event: 'confirmClearAll',
+        handler: evt => {
+          const evtData = {
+            timeStamp: evt.timeStamp,
+            type: evt.type,
+            confirmationMessage: evt.detail.confirmationMessage,
+            clearAllAction: evt.detail.clearAllAction,
+            btnCoords: evt.detail.btnCoords,
+          }
+          this.opts.confirmClearAll(evtData)
+        },
+      },
+      {
+        event: EVENT_FORMEO_SAVED,
+        handler: ({ timeStamp, type, detail: { formData } }) => {
+          this.opts.onSave({ timeStamp, type, formData })
+        },
+      },
+      {
+        event: 'formeoLoaded',
+        handler: evt => {
+          this.opts.formeoLoaded(evt.detail.formeo)
+        },
+      },
+    ]
+
+    // Attach listeners to the container
+    for (const { event, handler } of listeners) {
+      this.container.addEventListener(event, handler)
+      this._listeners.push({ event, handler })
+    }
+
+    // Window resize handler - scoped to this editor's columns and controls
+    let throttling
+    const onResizeWindow = () => {
+      throttling =
+        throttling ||
+        globalThis.requestAnimationFrame(() => {
+          throttling = false
+          for (const column of Object.values(columns.data)) {
+            column.dom.classList.add(NO_TRANSITION_CLASS_NAME)
+            controls.dom.classList.add(NO_TRANSITION_CLASS_NAME)
+            controls.panels.nav.refresh()
+            column.refreshFieldPanels()
+            throttle(() => {
+              column.dom.classList.remove(NO_TRANSITION_CLASS_NAME)
+              controls.dom.classList.remove(NO_TRANSITION_CLASS_NAME)
+            }, ANIMATION_SPEED_BASE)
+          }
+        })
+    }
+    globalThis.window.addEventListener('resize', onResizeWindow)
+    this._listeners.push({ event: 'resize', handler: onResizeWindow, target: globalThis.window })
+  }
+
+  /**
+   * Remove all registered DOM event listeners (cleanup on destroy).
+   */
+  removeListeners() {
+    for (const { event, handler, target } of this._listeners) {
+      ;(target || this.container).removeEventListener(event, handler)
+    }
+    this._listeners = []
+  }
 }
 
-// handle event
-window.addEventListener('resize', onResizeWindow)
+// Singleton instance for backward compatibility with existing tests and code
+const events = new Events()
 
 export default events

--- a/src/lib/js/common/events.js
+++ b/src/lib/js/common/events.js
@@ -78,6 +78,9 @@ export class Events {
     // Auto-register listeners for the singleton (backward compatibility with tests)
     // Per-instance Events objects should call registerListeners() explicitly
     if (this === events) {
+      if (this._autoRegistered) {
+        this.removeListeners()
+      }
       this._autoRegistered = true
       for (const { event, handler } of this._getBasicListeners()) {
         this.container.addEventListener(event, handler)

--- a/src/lib/js/components/columns/column.js
+++ b/src/lib/js/components/columns/column.js
@@ -1,7 +1,6 @@
 import i18n from '@draggable/i18n'
 import Sortable from 'sortablejs'
 import dom from '../../common/dom.js'
-import events from '../../common/events.js'
 import h from '../../common/helpers.mjs'
 import { COLUMN_CLASSNAME, FIELD_CLASSNAME } from '../../constants.js'
 import Component from '../component.js'
@@ -60,13 +59,6 @@ export default class Column extends Component {
     })
 
     this.processConfig()
-
-    events.columnResized = new window.CustomEvent('columnResized', {
-      detail: {
-        column: this.dom,
-        instance: this,
-      },
-    })
 
     Sortable.create(childWrap, {
       animation: 150,

--- a/src/lib/js/components/columns/index.js
+++ b/src/lib/js/components/columns/index.js
@@ -9,8 +9,13 @@ const DEFAULT_CONFIG = {
 }
 
 export class Columns extends ComponentData {
-  constructor(columnData) {
-    super('columns', columnData)
+  /**
+   * @param {Object} [data] - Initial column data
+   * @param {Object} [events] - Events instance for dispatching events
+   * @param {Object} [components] - Components instance for component lookup
+   */
+  constructor(data = Object.create(null), events = null, components = null) {
+    super('columns', data, events, components)
     this.config = { all: DEFAULT_CONFIG }
   }
   Component(data) {
@@ -18,6 +23,7 @@ export class Columns extends ComponentData {
   }
 }
 
+// Singleton instance for backward compatibility
 const columns = new Columns()
 
 export default columns

--- a/src/lib/js/components/component-data.js
+++ b/src/lib/js/components/component-data.js
@@ -1,10 +1,21 @@
-import events from '../common/events.js'
 import { clone, merge, parseData, uuid } from '../common/utils/index.mjs'
 import { get } from '../common/utils/object.mjs'
 import { EVENT_FORMEO_ADDED_COLUMN, EVENT_FORMEO_ADDED_FIELD, EVENT_FORMEO_ADDED_ROW } from '../constants.js'
 import Data from './data.js'
 
 export default class ComponentData extends Data {
+  /**
+   * @param {string} name - Component type name (e.g., 'rows', 'columns')
+   * @param {Object} [data] - Initial data
+   * @param {Object} [events] - Events instance for dispatching events
+   * @param {Object} [components] - Components instance for component lookup
+   */
+  constructor(name, data = Object.create(null), events = null, components = null) {
+    super(name, data, events)
+    this.components = components
+    this.conditionMap = new Map()
+  }
+
   load = dataArg => {
     const data = parseData(dataArg)
     this.empty()
@@ -16,24 +27,27 @@ export default class ComponentData extends Data {
 
   /**
    * Retrieves data from the specified path or adds new data if no path is provided.
-   *
-   * @param {string} [path] - The path to retrieve data from. If not provided, new data will be added.
-   * @returns {*} The data retrieved from the specified path or the result of adding new data.
+   * @param {string} [path] - The path to retrieve data from
+   * @returns {*} The data retrieved or the result of adding new data
    */
   get = path => (path ? get(this.data, path) : this.add())
 
   /**
    * Adds a new component with the given id and data.
-   *
-   * @param {string} id - The unique identifier for the component. If not provided, a new UUID will be generated.
-   * @param {Object} [data=Object.create(null)] - The data to initialize the component with.
-   * @returns {Object} The newly created component.
+   * @param {string} [id] - The unique identifier for the component
+   * @param {Object} [data] - The data to initialize the component with
+   * @returns {Object} The newly created component
    */
   add = (id, data = Object.create(null)) => {
     const elemId = id || uuid()
     const component = this.Component({ ...data, id: elemId })
     this.data[elemId] = component
     this.active = component
+
+    // Pass components reference to the component if available
+    if (this.components && component.setComponents) {
+      component.setComponents(this.components)
+    }
 
     // Dispatch add events based on component type
     const componentEventMap = {
@@ -43,8 +57,8 @@ export default class ComponentData extends Data {
     }
 
     const addEvent = componentEventMap[this.name]
-    if (addEvent) {
-      events.formeoUpdated(
+    if (addEvent && this.events) {
+      this.events.formeoUpdated(
         {
           entity: component,
           componentId: elemId,
@@ -59,7 +73,7 @@ export default class ComponentData extends Data {
   }
 
   /**
-   * removes a component form the index
+   * Removes a component from the index
    * @param {String|Array} componentId
    */
   remove = componentId => {
@@ -76,9 +90,8 @@ export default class ComponentData extends Data {
 
   /**
    * Deletes a component from the data object.
-   *
-   * @param {string} componentId - The ID of the component to delete.
-   * @returns {string} The ID of the deleted component.
+   * @param {string} componentId - The ID of the component to delete
+   * @returns {string} The ID of the deleted component
    */
   delete = componentId => {
     delete this.data[componentId]
@@ -87,7 +100,7 @@ export default class ComponentData extends Data {
 
   /**
    * Clears all instances from the store
-   * @param {Object} evt
+   * @param {boolean} [isAnimated=true]
    */
   clearAll = (isAnimated = true) => {
     const promises = Object.values(this.data).map(component => component.empty(isAnimated))
@@ -95,8 +108,7 @@ export default class ComponentData extends Data {
   }
 
   /**
-   * Extends the configVal for a component type,
-   * eventually read by Component
+   * Extends the configVal for a component type
    * @return {Object} configVal
    */
   set config(config) {
@@ -110,6 +122,4 @@ export default class ComponentData extends Data {
   get config() {
     return this.configVal
   }
-
-  conditionMap = new Map()
 }

--- a/src/lib/js/components/component-data.js
+++ b/src/lib/js/components/component-data.js
@@ -40,7 +40,12 @@ export default class ComponentData extends Data {
    */
   add = (id, data = Object.create(null)) => {
     const elemId = id || uuid()
-    const component = this.Component({ ...data, id: elemId })
+    const component = this.Component({
+      ...data,
+      id: elemId,
+      __events: this.events,
+      __components: this.components,
+    })
     this.data[elemId] = component
     this.active = component
 

--- a/src/lib/js/components/component.js
+++ b/src/lib/js/components/component.js
@@ -22,11 +22,9 @@ import {
 } from '../constants.js'
 import Data from './data.js'
 import EditPanel from './edit-panel/edit-panel.js'
-// Components is imported at the end of the file after circular dependencies are resolved
+// Keep global Components import for backward compatibility and fallback
 import Components from './index.js'
 import Panels from './panels.js'
-
-// import Controls from './controls/index.js'
 
 let Controls = null
 
@@ -40,13 +38,24 @@ export default class Component extends Data {
     this.shortId = this.id.slice(0, this.id.indexOf('-'))
     this.name = name
     this.indexName = `${name}s`
-    this.config = { ...data.config, ...Components[`${this.name}s`].config }
+    // Use instance components if set, otherwise fall back to global Components
+    const componentsRef = this.components || Components
+    this.config = { ...data.config, ...componentsRef[`${this.name}s`]?.config }
     this.address = `${this.name}s.${this.id}`
     this.dataPath = `${this.address}.`
     // this.observer = new window.MutationObserver(this.mutationHandler)
     this.editPanels = new Map()
     this.eventListeners = new Map()
     this.initEventHandlers()
+  }
+
+  /**
+   * Set the Components instance reference for this component.
+   * Called by ComponentData.add() after the component is created.
+   * @param {Object} components - The Components instance
+   */
+  setComponents(components) {
+    this.components = components
   }
 
   /**
@@ -194,7 +203,8 @@ export default class Component extends Data {
     forEach(children, child => child.remove())
 
     this.dom.remove()
-    remove(Components.getAddress(`${parent.name}s.${parent.id}.children`), this.id)
+    const componentsRef = this.components || Components
+    remove(componentsRef.getAddress(`${parent.name}s.${parent.id}.children`), this.id)
 
     if (!parent.children.length) {
       parent.emptyClass()
@@ -213,7 +223,8 @@ export default class Component extends Data {
 
     const removeEvent = componentEventMap[this.name]
     if (removeEvent) {
-      events.formeoUpdated(
+      const eventsRef = this.components?.events || events
+      eventsRef.formeoUpdated(
         {
           componentId: this.id,
           componentType: this.name,
@@ -223,7 +234,7 @@ export default class Component extends Data {
       )
     }
 
-    return Components[`${this.name}s`].delete(this.id)
+    return (this.components || Components)[`${this.name}s`].delete(this.id)
   }
 
   /**
@@ -251,16 +262,17 @@ export default class Component extends Data {
    */
   getActionButtons() {
     const hoverClassnames = [`hovering-${this.name}`, 'hovering']
+    const componentsRef = this.components || Components
     return {
       className: [`${this.name}-actions`, 'group-actions'],
       action: {
         mouseenter: () => {
-          Components.stages.active.dom.classList.add(`active-hover-${this.name}`)
+          componentsRef.stages.active.dom.classList.add(`active-hover-${this.name}`)
           this.dom.classList.add(...hoverClassnames)
         },
         mouseleave: ({ target }) => {
           this.dom.classList.remove(...hoverClassnames)
-          Components.stages.active.dom.classList.remove(`active-hover-${this.name}`)
+          componentsRef.stages.active.dom.classList.remove(`active-hover-${this.name}`)
           target.removeAttribute('style')
         },
       },
@@ -426,7 +438,8 @@ export default class Component extends Data {
     }
     const domChildren = this.domChildren
     const childGroup = CHILD_TYPE_MAP.get(this.name)
-    return map(domChildren, child => Components.getAddress(`${childGroup}s.${child.id}`)).filter(Boolean)
+    const componentsRef = this.components || Components
+    return map(domChildren, child => componentsRef.getAddress(`${childGroup}s.${child.id}`)).filter(Boolean)
   }
 
   loadChildren = (children = this.data.children) => children.map(rowId => this.addChild({ id: rowId }))
@@ -456,9 +469,11 @@ export default class Component extends Data {
     }
 
     const childComponentType = `${childGroup}s`
+    const componentsRef = this.components || Components
 
     const child =
-      Components.getAddress(`${childComponentType}.${childId}`) || Components[childComponentType].add(childId, data)
+      componentsRef.getAddress(`${childComponentType}.${childId}`) ||
+      componentsRef[childComponentType].add(childId, data)
 
     if (index >= childWrap.children.length) {
       childWrap.appendChild(child.dom)
@@ -736,7 +751,8 @@ export default class Component extends Data {
 
   getComponent(path) {
     const [type, id] = path.split('.')
-    const group = Components[type]
+    const componentsRef = this.components || Components
+    const group = componentsRef[type]
     return id === this.id ? this : group?.get(id)
   }
 
@@ -945,7 +961,7 @@ export default class Component extends Data {
       const panelData = this.get(panelName)
       const propType = dom.childType(panelData)
       if (editable.has(propType)) {
-        const editPanel = new EditPanel(panelData, panelName, this)
+        const editPanel = new EditPanel(panelData, panelName, this, this.components?.actions)
         this.editPanels.set(editPanel.name, editPanel)
       }
     }

--- a/src/lib/js/components/component.js
+++ b/src/lib/js/components/component.js
@@ -32,14 +32,15 @@ const propertyOptions = objectFromStringArray(PROPERTY_OPTIONS)
 
 export default class Component extends Data {
   constructor(name, dataArg = {}) {
-    const data = { ...dataArg, id: dataArg.id || uuid() }
-    super(name, data)
+    const { __events: eventsRefFromData, __components: componentsRefFromData, ...componentDataArg } = dataArg
+    const data = { ...componentDataArg, id: componentDataArg.id || uuid() }
+    const componentsRef = componentsRefFromData || Components
+    super(name, data, eventsRefFromData || componentsRef?.events || events)
     this.id = data.id
     this.shortId = this.id.slice(0, this.id.indexOf('-'))
     this.name = name
     this.indexName = `${name}s`
-    // Use instance components if set, otherwise fall back to global Components
-    const componentsRef = this.components || Components
+    this.components = componentsRef
     this.config = { ...data.config, ...componentsRef[`${this.name}s`]?.config }
     this.address = `${this.name}s.${this.id}`
     this.dataPath = `${this.address}.`
@@ -56,6 +57,7 @@ export default class Component extends Data {
    */
   setComponents(components) {
     this.components = components
+    this.events = components?.events || this.events
   }
 
   /**

--- a/src/lib/js/components/controls/index.js
+++ b/src/lib/js/components/controls/index.js
@@ -17,8 +17,12 @@ import defaultOptions from './options.js'
  *
  */
 export class Controls {
-  constructor() {
+  /**
+   * @param {Object} [components] - The Components instance for this editor
+   */
+  constructor(components = null) {
     this.data = new Map()
+    this.components = components
 
     this.buttonActions = {
       // this is used for keyboard navigation. when tabbing through controls it
@@ -154,17 +158,20 @@ export class Controls {
     if (this.options.disable.formActions === true) {
       return null
     }
+    const componentsRef = this.components
     const clearBtn = {
       ...dom.btnTemplate({ content: [dom.icon('bin'), i18n.get('clear')], title: i18n.get('clearAll') }),
       className: ['clear-form'],
       action: {
         click: evt => {
-          if (Rows.size) {
+          const rowsRef = componentsRef?.rows || Rows
+          if (rowsRef.size) {
             events.confirmClearAll = new window.CustomEvent('confirmClearAll', {
               detail: {
                 confirmationMessage: i18n.get('confirmClearAll'),
                 clearAllAction: () => {
-                  Stages.clearAll().then(() => {
+                  const stagesRef = componentsRef?.stages || Stages
+                  stagesRef.clearAll().then(() => {
                     const evtData = {
                       src: evt.target,
                     }
@@ -188,9 +195,8 @@ export class Controls {
       className: ['save-form'],
       action: {
         click: async ({ target }) => {
-          // Dynamic import to avoid circular dependency
-          const { default: Components } = await import('../index.js')
-          const { formData } = Components
+          const comps = componentsRef || (await import('../index.js')).default
+          const { formData } = comps
           const saveEvt = {
             action: () => {},
             coords: dom.coords(target),
@@ -350,7 +356,10 @@ export class Controls {
   }
 
   layoutTypes = {
-    row: () => Stages.active.addChild(),
+    row: () => {
+      const stagesRef = this.components?.stages || Stages
+      return stagesRef.active.addChild()
+    },
     column: () => this.layoutTypes.row().addChild(),
     field: controlData => this.layoutTypes.column().addChild(controlData),
   }

--- a/src/lib/js/components/controls/index.js
+++ b/src/lib/js/components/controls/index.js
@@ -159,6 +159,8 @@ export class Controls {
       return null
     }
     const componentsRef = this.components
+    const actionsRef = componentsRef?.actions || actions
+    const eventsRef = componentsRef?.events || events
     const clearBtn = {
       ...dom.btnTemplate({ content: [dom.icon('bin'), i18n.get('clear')], title: i18n.get('clearAll') }),
       className: ['clear-form'],
@@ -166,7 +168,7 @@ export class Controls {
         click: evt => {
           const rowsRef = componentsRef?.rows || Rows
           if (rowsRef.size) {
-            events.confirmClearAll = new window.CustomEvent('confirmClearAll', {
+            const confirmClearEvent = new window.CustomEvent('confirmClearAll', {
               detail: {
                 confirmationMessage: i18n.get('confirmClearAll'),
                 clearAllAction: () => {
@@ -175,14 +177,14 @@ export class Controls {
                     const evtData = {
                       src: evt.target,
                     }
-                    events.formeoCleared(evtData)
+                    eventsRef.formeoCleared(evtData)
                   })
                 },
                 btnCoords: dom.coords(evt.target),
               },
             })
 
-            document.dispatchEvent(events.confirmClearAll)
+            eventsRef.container.dispatchEvent(confirmClearEvent)
           } else {
             window.alert(i18n.get('cannotClearFields'))
           }
@@ -203,9 +205,9 @@ export class Controls {
             message: '',
             button: target,
           }
-          actions.click.btn(saveEvt)
+          actionsRef.click.btn(saveEvt)
 
-          return actions.save.form(formData)
+          return actionsRef.save.form(formData)
         },
       },
     }

--- a/src/lib/js/components/data.js
+++ b/src/lib/js/components/data.js
@@ -1,5 +1,4 @@
 import isEqual from 'lodash/isEqual.js'
-import events from '../common/events.js'
 import { uuid } from '../common/utils/index.mjs'
 import { get, set } from '../common/utils/object.mjs'
 import { splitAddress } from '../common/utils/string.mjs'
@@ -24,11 +23,19 @@ const getChangeType = (oldVal, newVal) => {
 }
 
 export default class Data {
-  constructor(name, data = Object.create(null)) {
+  /**
+   * @param {string} name - Data store name
+   * @param {Object} [data] - Initial data
+   * @param {Object} [events] - Events instance for dispatching update events
+   */
+  constructor(name, data = Object.create(null), events = null) {
     this.name = name
     this.data = data
     this.dataPath = ''
+    /** @type {Object|null} */
+    this.events = events
   }
+
   get size() {
     return Object.keys(this.data).length
   }
@@ -54,7 +61,7 @@ export default class Data {
       }
     }
 
-    if (!this.disableEvents) {
+    if (!this.disableEvents && this.events) {
       const evtData = {
         entity: this,
         dataPath: this.dataPath.replace(/\.+$/, ''),
@@ -69,7 +76,7 @@ export default class Data {
       }
 
       // Dispatch the generic formeoUpdated event
-      events.formeoUpdated(evtData)
+      this.events.formeoUpdated(evtData)
 
       // Dispatch component-specific events based on the component type
       if (this.name) {
@@ -82,7 +89,7 @@ export default class Data {
 
         const specificEvent = componentEventMap[this.name]
         if (specificEvent) {
-          events.formeoUpdated(evtData, specificEvent)
+          this.events.formeoUpdated(evtData, specificEvent)
         }
       }
     }

--- a/src/lib/js/components/edit-panel/condition.mjs
+++ b/src/lib/js/components/edit-panel/condition.mjs
@@ -1,6 +1,7 @@
 import i18n from '@draggable/i18n'
 import animate from '../../common/animation.js'
 import dom from '../../common/dom.js'
+// Keep global imports for backward compatibility and fallback
 import events from '../../common/events.js'
 import { debounce } from '../../common/utils/index.mjs'
 import { ANIMATION_SPEED_FAST, CONDITION_INPUT_ORDER } from '../../constants.js'
@@ -17,7 +18,12 @@ function orderConditionValues(conditionValues, fieldOrder = CONDITION_INPUT_ORDE
 }
 
 export class Condition {
-  constructor({ conditionValues, conditionType, conditionCount, index }, parent) {
+  constructor(
+    { conditionValues, conditionType, conditionCount, index },
+    parent,
+    eventsInstance = null,
+    componentsInstance = null
+  ) {
     this.values = new Map(orderConditionValues(conditionValues))
     this.conditionType = conditionType
     this.parent = parent
@@ -25,6 +31,8 @@ export class Condition {
     this.fields = new Map()
     this.conditionCount = conditionCount
     this.index = index
+    this.events = eventsInstance || events
+    this.components = componentsInstance || Components
 
     this.dom = this.generateDom()
   }
@@ -142,8 +150,8 @@ export class Condition {
   }
 
   updateDataDebounced = debounce(evtData => {
-    events.formeoUpdated(evtData)
-    Components.setAddress(evtData.dataPath, evtData.value)
+    this.events.formeoUpdated(evtData)
+    this.components.setAddress(evtData.dataPath, evtData.value)
   })
 
   onChangeCondition = ({ key, target }) => {

--- a/src/lib/js/components/edit-panel/condition.mjs
+++ b/src/lib/js/components/edit-panel/condition.mjs
@@ -46,9 +46,10 @@ export class Condition {
   }
 
   destroy() {
-    const conditions = Components.getAddress(this.baseAddress)
+    const componentsRef = this.components || Components
+    const conditions = componentsRef.getAddress(this.baseAddress)
     conditions.splice(this.index, 1)
-    Components.setAddress(this.baseAddress, conditions)
+    componentsRef.setAddress(this.baseAddress, conditions)
     animate.slideUp(this.dom, ANIMATION_SPEED_FAST, () => {
       this.dom.remove()
     })

--- a/src/lib/js/components/edit-panel/edit-panel-item.mjs
+++ b/src/lib/js/components/edit-panel/edit-panel-item.mjs
@@ -143,7 +143,12 @@ export default class EditPanelItem {
       condition = { conditionValues: newConditionData, conditionCount, index: conditionCount }
     }
 
-    const conditionField = new Condition({ conditionType, ...condition }, this)
+    // Get per-instance references from the field component
+    const fieldComponent = this.field
+    const eventsInstance = fieldComponent?.components?.events
+    const componentsInstance = fieldComponent?.components
+
+    const conditionField = new Condition({ conditionType, ...condition }, this, eventsInstance, componentsInstance)
 
     conditionTypeWrap.appendChild(conditionField.dom)
 

--- a/src/lib/js/components/edit-panel/edit-panel.js
+++ b/src/lib/js/components/edit-panel/edit-panel.js
@@ -1,4 +1,5 @@
 import i18n from '@draggable/i18n'
+// Keep global actions import for backward compatibility
 import actions from '../../common/actions.js'
 import dom from '../../common/dom.js'
 import { capitalize, safeAttrName } from '../../common/helpers.mjs'
@@ -42,13 +43,15 @@ export default class EditPanel {
    * Set defaults and load panelData
    * @param  {Object} panelData existing field ID
    * @param  {String} panelName name of panel
-   * @param  {String} component
+   * @param  {Object} component the Component instance
+   * @param  {Object} [actions] per-instance Actions object (falls back to global)
    * @return {Object} field object
    */
-  constructor(panelData, panelName, component) {
+  constructor(panelData, panelName, component, actionsInstance = null) {
     this.type = dom.childType(panelData)
     this.name = panelName
     this.component = component
+    this.actions = actionsInstance || actions
 
     this.panelConfig = this.getPanelConfig(this.data)
   }
@@ -185,7 +188,7 @@ export default class EditPanel {
           })
 
           // Run Action Hook
-          actions.add[type](addEvt)
+          this.actions.add[type](addEvt)
 
           // Fire Event
           document.dispatchEvent(customEvt)
@@ -340,7 +343,7 @@ export default class EditPanel {
     }
 
     // Run Action Hook
-    actions.remove[this.name](removeEvt)
+    this.actions.remove[this.name](removeEvt)
 
     // Fire Event
     const eventType = toTitleCase(this.name)

--- a/src/lib/js/components/fields/index.js
+++ b/src/lib/js/components/fields/index.js
@@ -1,7 +1,6 @@
 import { parseData } from '../../common/utils/index.mjs'
 import { get, set } from '../../common/utils/object.mjs'
 import ComponentData from '../component-data.js'
-import Controls from '../controls/index.js'
 import Field from './field.js'
 
 const DEFAULT_CONFIG = () => ({
@@ -24,17 +23,34 @@ const DEFAULT_CONFIG = () => ({
 })
 
 export class Fields extends ComponentData {
-  constructor(fieldData) {
-    super('fields', fieldData)
+  /**
+   * @param {Object} [data] - Initial field data
+   * @param {Object} [events] - Events instance for dispatching events
+   * @param {Object} [components] - Components instance for component lookup
+   */
+  constructor(data = Object.create(null), events = null, components = null) {
+    super('fields', data, events, components)
     this.config = { all: DEFAULT_CONFIG() }
+    /** @type {Object|null} */
+    this.controls = null
   }
+
+  /**
+   * Set the Controls instance for auto-registering controls.
+   * @param {Object} controls - The Controls instance
+   */
+  setControls(controls) {
+    this.controls = controls
+  }
+
   Component(data) {
     return new Field(data)
   }
+
   get = path => {
     let found = path && get(this.data, path)
-    if (!found) {
-      const control = Controls.get(path)
+    if (!found && this.controls) {
+      const control = this.controls.get(path)
       if (control) {
         found = this.add(null, control.controlData)
       }
@@ -69,7 +85,7 @@ export class Fields extends ComponentData {
     for (const [key, val] of Object.entries(allFieldData)) {
       const { meta, ...data } = val
       // meta object is only for controls, we want to migrate it out of field data
-      // we only need the control id to tie actions back to control definitons
+      // we only need the control id to tie actions back to control definitions
       if (meta?.id) {
         set(data, 'config.controlId', meta?.id)
       }
@@ -80,6 +96,7 @@ export class Fields extends ComponentData {
   }
 }
 
+// Singleton instance for backward compatibility
 const fields = new Fields()
 
 export default fields

--- a/src/lib/js/components/index.js
+++ b/src/lib/js/components/index.js
@@ -2,18 +2,16 @@
 import { buildFlatDataStructure, clone, isAddress, parseData, sessionStorage } from '../common/utils/index.mjs'
 import { splitAddress } from '../common/utils/string.mjs'
 import { COMPONENT_INDEX_TYPE_MAP, DEFAULT_FORMDATA, SESSION_FORMDATA_KEY, version } from '../constants.js'
-import ColumnsData from './columns/index.js'
+import { Columns as ColumnsClass } from './columns/index.js'
 import Data from './data.js'
-import FieldsData from './fields/index.js'
-import RowsData from './rows/index.js'
-import StagesData from './stages/index.js'
+import { Fields as FieldsClass } from './fields/index.js'
+import { Rows as RowsClass } from './rows/index.js'
+import { Stages as StagesClass } from './stages/index.js'
 import ControlsData from './controls/index.js'
 export { Dialog } from './dialog.js'
 
-export const Stages = StagesData
-export const Rows = RowsData
-export const Columns = ColumnsData
-export const Fields = FieldsData
+// Re-export class constructors for per-instance creation
+export { StagesClass as Stages, RowsClass as Rows, ColumnsClass as Columns, FieldsClass as Fields }
 export const Controls = ControlsData
 
 const getFormData = (formData, useSessionStorage = false) => {
@@ -44,28 +42,47 @@ const getFormData = (formData, useSessionStorage = false) => {
   return DEFAULT_FORMDATA()
 }
 
+/**
+ * Components class manages the component hierarchy (stages, rows, columns, fields).
+ * Each FormeoEditor instance creates its own Components object so that
+ * multiple editors on the same page maintain separate state.
+ */
 export class Components extends Data {
-  constructor() {
-    super('components')
+  /**
+   * @param {Object} events - The Events instance for this editor
+   * @param {Object} actions - The Actions instance for this editor
+   */
+  constructor(events, actions = null) {
+    super('components', Object.create(null), events)
     this.disableEvents = true
-    this.stages = Stages
-    this.rows = Rows
-    this.columns = Columns
-    this.fields = Fields
-    this.controls = Controls
+    this.actions = actions
+
+    // Create per-instance data stores
+    this.stages = new StagesClass(undefined, events, this)
+    this.rows = new RowsClass(undefined, events, this)
+    this.columns = new ColumnsClass(undefined, events, this)
+    this.fields = new FieldsClass(undefined, events, this)
   }
 
-  load = (formDataArg, opts) => {
+  /**
+   * Set the Controls instance for the fields data store.
+   * @param {Object} controls - The Controls instance
+   */
+  setControls(controls) {
+    this.fields.setControls(controls)
+  }
+
+  load = (formDataArg, opts = {}) => {
     this.empty()
     const formData = getFormData(formDataArg, opts.sessionStorage)
 
     this.opts = opts
 
     this.set('id', formData.id)
-    this.add('stages', Stages.load(formData.stages))
-    this.add('rows', Rows.load(formData.rows))
-    this.add('columns', Columns.load(formData.columns))
-    this.add('fields', Fields.load(formData.fields))
+    this.add('stages', this.stages.load(formData.stages))
+    this.add('rows', this.rows.load(formData.rows))
+    this.add('columns', this.columns.load(formData.columns))
+    this.add('fields', this.fields.load(formData.fields))
 
     for (const stage of Object.values(this.get('stages'))) {
       stage.loadChildren()
@@ -75,7 +92,7 @@ export class Components extends Data {
   }
 
   /**
-   * flattens the component tree
+   * Flattens the component tree
    * @returns {Object} where keys contains component type
    */
   flatList() {
@@ -105,19 +122,19 @@ export class Components extends Data {
   get formData() {
     return {
       id: this.get('id'),
-      stages: StagesData.getData(),
-      rows: RowsData.getData(),
-      columns: ColumnsData.getData(),
-      fields: FieldsData.getData(),
+      stages: this.stages.getData(),
+      rows: this.rows.getData(),
+      columns: this.columns.getData(),
+      fields: this.fields.getData(),
     }
   }
 
   set config(config) {
     const { stages, rows, columns, fields } = config
-    Stages.config = stages
-    Rows.config = rows
-    Columns.config = columns
-    Fields.config = fields
+    this.stages.config = stages
+    this.rows.config = rows
+    this.columns.config = columns
+    this.fields.config = fields
   }
 
   getIndex(type) {
@@ -125,7 +142,7 @@ export class Components extends Data {
   }
 
   /**
-   * call `set` on a component in memory
+   * Call `set` on a component in memory
    */
   setAddress(fullAddress, value) {
     if (!isAddress(fullAddress)) {
@@ -159,6 +176,7 @@ export class Components extends Data {
   }
 }
 
-const components = new Components()
+// Singleton instance for backward compatibility
+const components = new Components(null)
 
 export default components

--- a/src/lib/js/components/multi-instance.test.js
+++ b/src/lib/js/components/multi-instance.test.js
@@ -1,0 +1,243 @@
+/**
+ * Multi-instance isolation tests (Issue #152)
+ * Verifies that multiple FormeoEditor instances on the same page
+ * maintain separate state (Components, Events, Actions).
+ */
+
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { Actions } from '../common/actions.js'
+import { Events } from '../common/events.js'
+import { Components } from './index.js'
+
+describe('Multi-instance isolation (Issue #152)', () => {
+  describe('Components isolation', () => {
+    it('should maintain separate formData between two Components instances', () => {
+      // Create two independent Components instances
+      const events1 = new Events()
+      events1.init({})
+      const actions1 = new Actions(events1)
+      actions1.init({})
+      const components1 = new Components(events1, actions1)
+
+      const events2 = new Events()
+      events2.init({})
+      const actions2 = new Actions(events2)
+      actions2.init({})
+      const components2 = new Components(events2, actions2)
+
+      // Load different data into each
+      const formData1 = {
+        id: 'form-editor-1',
+        stages: {
+          'stage-1': {
+            id: 'stage-1',
+            attrs: { title: 'Editor 1 Stage' },
+            children: ['row-1'],
+          },
+        },
+        rows: {
+          'row-1': {
+            id: 'row-1',
+            children: ['col-1'],
+          },
+        },
+        columns: {
+          'col-1': {
+            id: 'col-1',
+            config: { width: '100%' },
+            children: ['field-1'],
+          },
+        },
+        fields: {
+          'field-1': {
+            id: 'field-1',
+            tag: 'input',
+            attrs: { type: 'text', label: 'Editor 1 Field' },
+            config: { label: 'Editor 1 Field' },
+          },
+        },
+      }
+
+      const formData2 = {
+        id: 'form-editor-2',
+        stages: {
+          'stage-2': {
+            id: 'stage-2',
+            attrs: { title: 'Editor 2 Stage' },
+            children: ['row-2'],
+          },
+        },
+        rows: {
+          'row-2': {
+            id: 'row-2',
+            children: ['col-2'],
+          },
+        },
+        columns: {
+          'col-2': {
+            id: 'col-2',
+            config: { width: '100%' },
+            children: ['field-2'],
+          },
+        },
+        fields: {
+          'field-2': {
+            id: 'field-2',
+            tag: 'textarea',
+            attrs: { label: 'Editor 2 Field' },
+            config: { label: 'Editor 2 Field' },
+          },
+        },
+      }
+
+      components1.load(formData1)
+
+      // Verify components1 has its data
+      assert.equal(components1.formData.id, 'form-editor-1')
+      assert.equal(Object.keys(components1.formData.stages).length, 1)
+      assert.equal(Object.keys(components1.formData.fields).length, 1)
+
+      // Load data into components2 - this should NOT affect components1
+      components2.load(formData2)
+
+      // Verify components2 has its own data
+      assert.equal(components2.formData.id, 'form-editor-2')
+      assert.equal(Object.keys(components2.formData.stages).length, 1)
+      assert.equal(Object.keys(components2.formData.fields).length, 1)
+
+      // CRITICAL: Verify components1 data was NOT overwritten
+      assert.equal(components1.formData.id, 'form-editor-1')
+      assert.equal(Object.keys(components1.formData.stages).length, 1)
+      assert.equal(Object.keys(components1.formData.fields).length, 1)
+      assert.equal(Object.keys(components1.formData.stages)[0], 'stage-1')
+      assert.equal(Object.keys(components1.formData.fields)[0], 'field-1')
+
+      // Verify the field types are correct
+      const field1 = components1.formData.fields['field-1']
+      const field2 = components2.formData.fields['field-2']
+      assert.equal(field1.tag, 'input')
+      assert.equal(field2.tag, 'textarea')
+    })
+
+    it('should have independent data stores (stages, rows, columns, fields)', () => {
+      const events1 = new Events()
+      events1.init({})
+      const actions1 = new Actions(events1)
+      actions1.init({})
+      const components1 = new Components(events1, actions1)
+
+      const events2 = new Events()
+      events2.init({})
+      const actions2 = new Actions(events2)
+      actions2.init({})
+      const components2 = new Components(events2, actions2)
+
+      // Verify data stores are NOT the same object
+      assert.notStrictEqual(components1.stages, components2.stages)
+      assert.notStrictEqual(components1.rows, components2.rows)
+      assert.notStrictEqual(components1.columns, components2.columns)
+      assert.notStrictEqual(components1.fields, components2.fields)
+
+      // Verify data stores start empty
+      assert.equal(components1.stages.size, 0)
+      assert.equal(components2.stages.size, 0)
+    })
+
+    it('should not share Components between editors when created via new Components()', () => {
+      const events1 = new Events()
+      events1.init({})
+      const actions1 = new Actions(events1)
+      actions1.init({})
+      const components1 = new Components(events1, actions1)
+
+      const events2 = new Events()
+      events2.init({})
+      const actions2 = new Actions(events2)
+      actions2.init({})
+      const components2 = new Components(events2, actions2)
+
+      // Load data into first
+      components1.load({
+        id: 'form-a',
+        stages: { 's-a': { id: 's-a', attrs: {}, children: [] } },
+        rows: {},
+        columns: {},
+        fields: {},
+      })
+
+      // Load data into second
+      components2.load({
+        id: 'form-b',
+        stages: { 's-b': { id: 's-b', attrs: {}, children: [] } },
+        rows: {},
+        columns: {},
+        fields: {},
+      })
+
+      // Verify isolation
+      assert.equal(components1.formData.id, 'form-a')
+      assert.equal(components2.formData.id, 'form-b')
+      assert.equal(Object.keys(components1.formData.stages)[0], 's-a')
+      assert.equal(Object.keys(components2.formData.stages)[0], 's-b')
+    })
+  })
+
+  describe('Events isolation', () => {
+    it('should maintain separate event options between two Events instances', () => {
+      const events1 = new Events()
+      events1.init({ debug: true, onSave: () => {} })
+
+      const events2 = new Events()
+      events2.init({ debug: false })
+
+      assert.equal(events1.opts.debug, true)
+      assert.equal(events2.opts.debug, false)
+      assert.notStrictEqual(events1.opts, events2.opts)
+    })
+
+    it('should dispatch events on the correct container', () => {
+      const container1 = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => true }
+      const container2 = { addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => true }
+
+      const events1 = new Events(container1)
+      events1.init({})
+
+      const events2 = new Events(container2)
+      events2.init({})
+
+      assert.strictEqual(events1.container, container1)
+      assert.strictEqual(events2.container, container2)
+    })
+  })
+
+  describe('Actions isolation', () => {
+    it('should maintain separate action options between two Actions instances', () => {
+      const events1 = new Events()
+      events1.init({})
+      const actions1 = new Actions(events1)
+      actions1.init({ sessionStorage: true })
+
+      const events2 = new Events()
+      events2.init({})
+      const actions2 = new Actions(events2)
+      actions2.init({ sessionStorage: false })
+
+      assert.equal(actions1.opts.sessionStorage, true)
+      assert.equal(actions2.opts.sessionStorage, false)
+    })
+
+    it('should reference the correct Events instance', () => {
+      const events1 = new Events()
+      events1.init({})
+      const actions1 = new Actions(events1)
+
+      const events2 = new Events()
+      events2.init({})
+      const actions2 = new Actions(events2)
+
+      assert.strictEqual(actions1.events, events1)
+      assert.strictEqual(actions2.events, events2)
+    })
+  })
+})

--- a/src/lib/js/components/rows/index.js
+++ b/src/lib/js/components/rows/index.js
@@ -9,8 +9,13 @@ const DEFAULT_CONFIG = {
 }
 
 export class Rows extends ComponentData {
-  constructor(rowData) {
-    super('rows', rowData)
+  /**
+   * @param {Object} [data] - Initial row data
+   * @param {Object} [events] - Events instance for dispatching events
+   * @param {Object} [components] - Components instance for component lookup
+   */
+  constructor(data = Object.create(null), events = null, components = null) {
+    super('rows', data, events, components)
     this.config = { all: DEFAULT_CONFIG }
   }
   Component(data) {
@@ -18,6 +23,7 @@ export class Rows extends ComponentData {
   }
 }
 
+// Singleton instance for backward compatibility
 const rows = new Rows()
 
 export default rows

--- a/src/lib/js/components/rows/row.js
+++ b/src/lib/js/components/rows/row.js
@@ -1,7 +1,6 @@
 import i18n from '@draggable/i18n'
 import Sortable from 'sortablejs'
 import dom from '../../common/dom.js'
-import events from '../../common/events.js'
 import { numToPercent } from '../../common/utils/index.mjs'
 import {
   ANIMATION_SPEED_FAST,
@@ -211,7 +210,15 @@ export default class Row extends Component {
         clearTimeout(refreshTimeout)
         column.refreshFieldPanels()
       }, ANIMATION_SPEED_FAST)
-      document.dispatchEvent(events.columnResized)
+      // Dispatch columnResized event scoped to this column's DOM element
+      const columnResizedEvent = new window.CustomEvent('columnResized', {
+        detail: {
+          column: colDom,
+          instance: column,
+        },
+        bubbles: true,
+      })
+      colDom.dispatchEvent(columnResizedEvent)
     }
 
     this.updateColumnPreset()

--- a/src/lib/js/components/stages/index.js
+++ b/src/lib/js/components/stages/index.js
@@ -8,16 +8,18 @@ const DEFAULT_CONFIG = () => ({
   },
   panels: {
     disabled: [],
-    // The 'order' array specifies the sequence in which the panels should be displayed.
-    // Each string in the array represents a panel type, such as 'attrs', 'options', or 'conditions'.
-    // By default, these panels are ordered as you see below, but can be override via formeo options.
     order: ['attrs', 'options', 'conditions'],
   },
 })
 
 export class Stages extends ComponentData {
-  constructor(stageData) {
-    super('stages', stageData)
+  /**
+   * @param {Object} [data] - Initial stage data
+   * @param {Object} [events] - Events instance for dispatching events
+   * @param {Object} [components] - Components instance for component lookup
+   */
+  constructor(data = Object.create(null), events = null, components = null) {
+    super('stages', data, events, components)
     this.config = { all: DEFAULT_CONFIG() }
   }
   Component(data) {
@@ -25,6 +27,7 @@ export class Stages extends ComponentData {
   }
 }
 
+// Singleton instance for backward compatibility
 const stages = new Stages()
 
 export default stages

--- a/src/lib/js/editor.js
+++ b/src/lib/js/editor.js
@@ -2,13 +2,13 @@ import '../sass/formeo.scss'
 import { enUS } from '@draggable/formeo-languages'
 import i18n from '@draggable/i18n'
 import { SmartTooltip } from '@draggable/tooltip'
-import Actions from './common/actions.js'
+import { Actions } from './common/actions.js'
 import dom from './common/dom.js'
-import Events from './common/events.js'
+import { Events } from './common/events.js'
 import { fetchFormeoStyle, fetchIcons } from './common/loaders.js'
 import { cleanFormData, clone, merge, sessionStorage } from './common/utils/index.mjs'
-import Controls from './components/controls/index.js'
-import Components from './components/index.js'
+import { Controls } from './components/controls/index.js'
+import { Components } from './components/index.js'
 import { defaults } from './config.js'
 import { DEFAULT_FORMDATA, SESSION_FORMDATA_KEY, SESSION_LOCALE_KEY } from './constants.js'
 
@@ -31,6 +31,19 @@ export class FormeoEditor {
   #initPromise = null
   #lockedFormData = null
   #dataLoadedOnce = false
+
+  /**
+   * Per-instance objects for multi-editor support
+   * @type {Events}
+   */
+  events = null
+
+  /**
+   * Per-instance Actions object
+   * @type {Actions}
+   */
+  actions = null
+
   /**
    * @param  {Object} options  formeo options
    * @param  {String|Object}   userFormData loaded formData
@@ -39,31 +52,32 @@ export class FormeoEditor {
   constructor({ formData, ...options }, userFormData) {
     const mergedOptions = merge(defaults.editor, options)
 
-    const { actions, events, debug, config, editorContainer, ...opts } = mergedOptions
+    const { actions: actionsOpts, events: eventsOpts, debug, config, editorContainer, ...opts } = mergedOptions
     if (editorContainer) {
       this.editorContainer =
         typeof editorContainer === 'string' ? document.querySelector(editorContainer) : editorContainer
     }
     this.opts = opts
     dom.setOptions = opts
-    Components.config = config
 
     // Lock user data immediately - this prevents race conditions during async init
     const providedData = userFormData || formData
     this.#lockedFormData = providedData ? cleanFormData(providedData) : null
     this.userFormData = this.#lockedFormData // backward compat
 
-    this.Components = Components
-    this.dom = dom
-    Events.init({ debug, ...events })
-    Actions.init({ debug, sessionStorage: opts.sessionStorage, ...actions })
+    // Create per-instance Events object
+    this.events = new Events(this.editorContainer || document)
+    this.events.init({ debug, ...eventsOpts })
 
-    // Load remote resources such as css and svg sprite
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', this.loadResources.bind(this))
-    } else {
-      this.loadResources()
-    }
+    // Create per-instance Actions object
+    this.actions = new Actions(this.events)
+    this.actions.init({ debug, sessionStorage: opts.sessionStorage, ...actionsOpts })
+
+    // Create per-instance Components object with its own data stores
+    this.Components = new Components(this.events, this.actions)
+    this.Components.config = config
+
+    this.dom = dom
   }
 
   get formData() {
@@ -150,9 +164,16 @@ export class FormeoEditor {
 
     this.#initState = INIT_STATES.INITIALIZING
 
-    this.#initPromise = Controls.init(this.opts.controls, this.opts.stickyControls)
+    // Create per-instance Controls with reference to this editor's Components
+    const controlsInstance = new Controls(this.Components)
+
+    this.#initPromise = controlsInstance
+      .init(this.opts.controls, this.opts.stickyControls)
       .then(controls => {
         this.controls = controls
+
+        // Link Controls back to Components for per-instance data access
+        this.Components.setControls(this.controls)
 
         // Only load data on FIRST init - prevents race condition
         if (!this.#dataLoadedOnce) {
@@ -160,7 +181,7 @@ export class FormeoEditor {
           this.#dataLoadedOnce = true
         }
 
-        this.formId = Components.get('id')
+        this.formId = this.Components.get('id')
         this.i18n = {
           setLang: this.#setLanguage.bind(this),
         }
@@ -169,6 +190,9 @@ export class FormeoEditor {
         this.#initState = INIT_STATES.READY
         this.opts.onLoad?.(this)
         this.tooltipInstance = new SmartTooltip()
+
+        // Register DOM event listeners for this editor instance
+        this.events.registerListeners(this.Components, this.Components.columns, this.controls)
 
         return this
       })
@@ -179,6 +203,25 @@ export class FormeoEditor {
       })
 
     return this.#initPromise
+  }
+
+  /**
+   * Destroy this editor instance and clean up resources
+   * @return {void}
+   */
+  destroy() {
+    // Remove DOM event listeners
+    this.events?.removeListeners()
+
+    // Remove editor DOM from container
+    if (this.editorContainer && this.editor) {
+      this.editorContainer.removeChild(this.editor)
+    }
+
+    // Clear data
+    this.Components?.empty()
+    this.#initState = INIT_STATES.CREATED
+    this.#dataLoadedOnce = false
   }
 
   /**
@@ -198,7 +241,10 @@ export class FormeoEditor {
    * @return {Promise}
    */
   async #refreshUI() {
-    this.controls = await Controls.init(this.opts.controls, this.opts.stickyControls)
+    // Create fresh Controls instance for UI refresh
+    const controlsInstance = new Controls(this.Components)
+    this.controls = await controlsInstance.init(this.opts.controls, this.opts.stickyControls)
+    this.Components.setControls(this.controls)
     this.render()
     return this
   }
@@ -295,7 +341,7 @@ export class FormeoEditor {
       return globalThis.requestAnimationFrame(() => this.render())
     }
 
-    this.stages = Object.values(Components.get('stages'))
+    this.stages = Object.values(this.Components.get('stages'))
     if (this.opts.controlOnLeft) {
       for (const stage of this.stages) {
         stage.dom.style.order = 1
@@ -324,13 +370,14 @@ export class FormeoEditor {
       this.editorContainer.appendChild(this.editor)
     }
 
-    Events.formeoLoaded = new globalThis.CustomEvent('formeoLoaded', {
+    // Dispatch formeoLoaded event using per-instance events
+    const formeoLoadedEvent = new globalThis.CustomEvent('formeoLoaded', {
       detail: {
         formeo: this,
       },
     })
 
-    document.dispatchEvent(Events.formeoLoaded)
+    this.events.container.dispatchEvent(formeoLoadedEvent)
   }
 }
 

--- a/src/lib/js/editor.js
+++ b/src/lib/js/editor.js
@@ -78,6 +78,13 @@ export class FormeoEditor {
     this.Components.config = config
 
     this.dom = dom
+    this.loadResources = this.loadResources.bind(this)
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', this.loadResources)
+    } else {
+      this.loadResources()
+    }
   }
 
   get formData() {
@@ -241,11 +248,13 @@ export class FormeoEditor {
    * @return {Promise}
    */
   async #refreshUI() {
+    this.events.removeListeners()
     // Create fresh Controls instance for UI refresh
     const controlsInstance = new Controls(this.Components)
     this.controls = await controlsInstance.init(this.opts.controls, this.opts.stickyControls)
     this.Components.setControls(this.controls)
     this.render()
+    this.events.registerListeners(this.Components, this.Components.columns, this.controls)
     return this
   }
 


### PR DESCRIPTION
## Problem

When multiple FormeoEditor instances were initialized on the same page, they shared module-level singleton objects (Components, Events, Actions, Controls). The second editor would overwrite the first editor's state, causing both editors to display identical content regardless of their individual formData.

See [Issue #152](https://github.com/Draggable/formeo/issues/152) (opened Nov 2018).

## Root Cause

1. **Components singleton** - Every editor imported the same Components instance. When editor 2 called `Components.load()`, it called `this.empty()` first, wiping editor 1's data.
2. **Events singleton** - `Events.init()` was called per-editor but overwrote the shared `opts` object.
3. **Actions singleton** - Same pattern - second editor overwrote first editor's action callbacks.
4. **Global event listeners** - `document.addEventListener()` calls registered at module load time referenced the shared Components singleton.

## Solution

Refactored module-level singletons into per-instance classes:

- **Events** - Now a class with per-instance `opts`, `container`, and listener registration via `registerListeners()`/`removeListeners()`
- **Actions** - Now a class with per-instance `opts` and Events reference
- **Components** - Now a class that accepts Events and Actions instances, creates per-instance data stores (stages, rows, columns, fields)
- **Controls** - Now accepts a Components instance for per-instance data access

The `FormeoEditor` constructor creates its own Events, Actions, Components, and Controls instances. Components receive their Components reference via `setComponents()` so they can look up data from the correct instance.

## Backward Compatibility

Singleton default exports are preserved for existing code paths and tests. Components fall back to the global singleton if no per-instance reference is set.

## Changes

- 18 files changed, +958/-353 lines
- Added 8 new multi-instance isolation unit tests (all passing)
- Added `destroy()` method for proper cleanup
- All 161 existing tests continue to pass

## Testing

- `npm test` - 161/161 pass
- `npm run lint` - clean
- `npm run build:lib` - succeeds
- Manual test HTML available at `test-multi-instance.html` (not committed)