### PR TITLE
Change  editorContainer to renderContainer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ const editor = new FormeoEditor({
     onSave: (formData) => {
       console.log('Form saved:', formData)
       // Render the form
-      renderer.render(formData)
+      renderer.render(formData.formData)
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ fetch('/api/forms', {
 // <div id="formeo-renderer"></div>
 
 const rendererOptions = {
-  editorContainer: '#formeo-renderer',
+  renderContainer: '#formeo-renderer',
   // Add any additional options here
 }
 
@@ -134,7 +134,7 @@ const editor = new FormeoEditor({
 
 // Set up the renderer
 const renderer = new FormeoRenderer({
-  editorContainer: '#formeo-renderer'
+  renderContainer: '#formeo-renderer'
 })
 ```
 


### PR DESCRIPTION
README correction:

Updated the configuration option from 'editorContainer' to 'renderContainer' in the FormeoRenderer setup.