### PR TITLE
fix: resolve condition sources for groups, selects and non-text inputs

### DIFF
--- a/src/lib/js/renderer/conditions.test.js
+++ b/src/lib/js/renderer/conditions.test.js
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import FormeoRenderer from './index.js'
+
+const TARGET_ID = 'target-1'
+
+const column = fieldId => [
+  `column-${fieldId}`,
+  { id: `column-${fieldId}`, config: { width: '100%' }, children: [fieldId] },
+]
+
+const buildFormData = fields => {
+  const fieldIds = Object.keys(fields)
+
+  return {
+    id: 'test-form',
+    stages: { 'stage-1': { id: 'stage-1', children: ['row-1'] } },
+    rows: { 'row-1': { id: 'row-1', config: {}, children: fieldIds.map(id => `column-${id}`) } },
+    columns: Object.fromEntries(fieldIds.map(column)),
+    fields,
+  }
+}
+
+const optionField = (id, type, options, extra = {}) => ({
+  id,
+  tag: type === 'select' ? 'select' : 'input',
+  attrs: type === 'select' ? {} : { type },
+  config: { label: `${type} field` },
+  options,
+  ...extra,
+})
+
+const inputField = (id, type = 'text', extra = {}) => ({
+  id,
+  tag: 'input',
+  attrs: { type },
+  config: { label: `${type} field` },
+  ...extra,
+})
+
+/**
+ * A condition hiding the target field while the source matches.
+ */
+const hideTargetWhen = ({ source, sourceProperty = 'value', comparison = 'equals', target }) => [
+  {
+    if: [{ source, sourceProperty, comparison, target, targetProperty: '' }],
+    then: [{ target: `fields.${TARGET_ID}`, targetProperty: 'isNotVisible', assignment: '', value: '' }],
+  },
+]
+
+describe('renderer conditions', () => {
+  let dom
+  let container
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><html><body><div id="container"></div></body></html>', {
+      url: 'http://localhost',
+      pretendToBeVisual: true,
+    })
+
+    global.document = dom.window.document
+    global.window = dom.window
+    global.Element = dom.window.Element
+    global.HTMLElement = dom.window.HTMLElement
+    global.Node = dom.window.Node
+    global.FormData = dom.window.FormData
+
+    container = dom.window.document.getElementById('container')
+  })
+
+  afterEach(() => {
+    for (const key of ['document', 'window', 'Element', 'HTMLElement', 'Node', 'FormData']) {
+      delete global[key]
+    }
+  })
+
+  const render = fields => {
+    const renderer = new FormeoRenderer({ renderContainer: container, formData: buildFormData(fields) })
+    renderer.render()
+
+    return renderer
+  }
+
+  const isTargetHidden = () => container.querySelector(`#f-${TARGET_ID}`).parentElement.hasAttribute('hidden')
+
+  const change = elem => elem.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
+
+  describe('select sources', () => {
+    test('re-evaluates when the selection changes', () => {
+      render({
+        'source-1': optionField('source-1', 'select', [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ]),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'b' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), false, 'target starts visible')
+
+      const select = container.querySelector('#f-source-1')
+      select.value = 'b'
+      change(select)
+
+      assert.equal(isTargetHidden(), true, 'selecting the matching option hides the target')
+    })
+
+    test('listens on the select itself, not on its options', () => {
+      render({
+        'source-1': optionField('source-1', 'select', [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ]),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'b' }),
+        }),
+      })
+
+      const select = container.querySelector('#f-source-1')
+      select.value = 'b'
+      // an option-level listener would never see this event
+      change(select.options[1])
+
+      assert.equal(isTargetHidden(), true, 'the event bubbling from an option still triggers the condition')
+    })
+
+    test('supports the legacy "checked" source property', () => {
+      render({
+        'source-1': optionField('source-1', 'select', [
+          { label: 'Gold', value: 'zlato' },
+          { label: 'Platinum', value: 'platina' },
+        ]),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', sourceProperty: 'checked', target: 'platina' }),
+        }),
+      })
+
+      const select = container.querySelector('#f-source-1')
+      select.value = 'platina'
+      change(select)
+
+      assert.equal(isTargetHidden(), true, '"checked" resolves to the selected value')
+    })
+  })
+
+  describe('radio group sources', () => {
+    const radioOptions = [
+      { label: 'One', value: 'r1' },
+      { label: 'Two', value: 'r2' },
+    ]
+
+    test('evaluates the checked option, not the group wrapper', () => {
+      render({
+        'source-1': optionField('source-1', 'radio', radioOptions),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'r2' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), false, 'nothing checked means no match')
+
+      const [, second] = container.querySelectorAll('#f-source-1 input')
+      second.checked = true
+      change(second)
+
+      assert.equal(isTargetHidden(), true, 'checking the matching radio hides the target')
+    })
+
+    test('applies a preselected option on load', () => {
+      render({
+        'source-1': optionField('source-1', 'radio', [
+          { label: 'One', value: 'r1' },
+          { label: 'Two', value: 'r2', selected: true },
+        ]),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'r2' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), true, 'the preselected option is evaluated during render')
+    })
+
+    test('does not match another option', () => {
+      render({
+        'source-1': optionField('source-1', 'radio', radioOptions),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'r2' }),
+        }),
+      })
+
+      const [first] = container.querySelectorAll('#f-source-1 input')
+      first.checked = true
+      change(first)
+
+      assert.equal(isTargetHidden(), false, 'a non-matching selection leaves the target alone')
+    })
+  })
+
+  describe('checkbox group sources', () => {
+    const checkboxOptions = [
+      { label: 'One', value: 'c1' },
+      { label: 'Two', value: 'c2' },
+    ]
+
+    test('matches a checked value with "equals"', () => {
+      render({
+        'source-1': optionField('source-1', 'checkbox', checkboxOptions),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: 'c2' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), false, 'nothing checked means no match')
+
+      const [, second] = container.querySelectorAll('#f-source-1 input')
+      second.checked = true
+      change(second)
+
+      assert.equal(isTargetHidden(), true, 'equals matches any checked value of the group')
+    })
+
+    test('matches a checked value with "contains" when several are checked', () => {
+      render({
+        'source-1': optionField('source-1', 'checkbox', checkboxOptions),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', comparison: 'contains', target: 'c2' }),
+        }),
+      })
+
+      const inputs = container.querySelectorAll('#f-source-1 input')
+      inputs[0].checked = true
+      inputs[1].checked = true
+      change(inputs[1])
+
+      assert.equal(isTargetHidden(), true, 'contains matches against every checked value')
+    })
+
+    test('"isNotChecked" resolves against the checked options of the group', () => {
+      render({
+        'source-1': optionField('source-1', 'checkbox', [
+          { label: 'One', value: 'c1', selected: true },
+          { label: 'Two', value: 'c2' },
+        ]),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', sourceProperty: 'isNotChecked', target: '' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), false, 'a boolean property resolving to false must not fall through')
+    })
+
+    test('"isNotChecked" matches an untouched group', () => {
+      render({
+        'source-1': optionField('source-1', 'checkbox', checkboxOptions),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', sourceProperty: 'isNotChecked', target: '' }),
+        }),
+      })
+
+      assert.equal(isTargetHidden(), true, 'no option checked means the group is not checked')
+    })
+  })
+
+  describe('text-like sources', () => {
+    test('re-evaluates a number input on input events', () => {
+      render({
+        'source-1': inputField('source-1', 'number'),
+        [TARGET_ID]: inputField(TARGET_ID, 'text', {
+          conditions: hideTargetWhen({ source: 'fields.source-1', target: '42' }),
+        }),
+      })
+
+      const input = container.querySelector('#f-source-1')
+      input.value = '42'
+      input.dispatchEvent(new dom.window.Event('input', { bubbles: true }))
+
+      assert.equal(isTargetHidden(), true, 'non-text input types are listened to as well')
+    })
+  })
+
+  describe('unusable conditions', () => {
+    test('renders a form whose condition points at a removed field', () => {
+      assert.doesNotThrow(() =>
+        render({
+          [TARGET_ID]: inputField(TARGET_ID, 'text', {
+            conditions: hideTargetWhen({ source: 'fields.deleted-field', target: 'x' }),
+          }),
+        })
+      )
+
+      assert.equal(isTargetHidden(), false, 'an unresolvable source never matches')
+    })
+
+    test('keeps applying the remaining conditions when one blows up', () => {
+      const conditions = [
+        ...hideTargetWhen({ source: 'fields.broken id!', target: 'x' }),
+        ...hideTargetWhen({ source: 'fields.source-1', target: 'b' }),
+      ]
+
+      assert.doesNotThrow(() =>
+        render({
+          'source-1': optionField('source-1', 'select', [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ]),
+          [TARGET_ID]: inputField(TARGET_ID, 'text', { conditions }),
+        })
+      )
+
+      const select = container.querySelector('#f-source-1')
+      select.value = 'b'
+      change(select)
+
+      assert.equal(isTargetHidden(), true, 'the healthy condition still works')
+    })
+  })
+})

--- a/src/lib/js/renderer/helpers.js
+++ b/src/lib/js/renderer/helpers.js
@@ -25,7 +25,7 @@ export const baseId = id => {
 const isVisible = elem => {
   if (!elem) return false
 
-  if (elem.hasAttribute('hidden') || elem.parentElement.hasAttribute('hidden')) {
+  if (elem.hasAttribute('hidden') || elem.parentElement?.hasAttribute('hidden')) {
     return false
   }
 
@@ -33,16 +33,76 @@ const isVisible = elem => {
   return !(computedStyle.display === 'none' || computedStyle.visibility === 'hidden' || computedStyle.opacity === '0')
 }
 
+const CHECKABLE_INPUT_SELECTOR = 'input[type="checkbox"], input[type="radio"]'
+const CHECKABLE_TYPES = new Set(['checkbox', 'radio'])
+
+const tagName = elem => elem?.tagName?.toLowerCase()
+
+const isCheckableInput = elem => tagName(elem) === 'input' && CHECKABLE_TYPES.has(elem.type)
+
+/**
+ * Radio and checkbox fields render as a wrapper holding one input per option, so a
+ * field address resolves to the wrapper rather than to anything carrying a value.
+ * @param  {Element} elem
+ * @return {Array<Element>|null} option inputs, or null when elem is not a group
+ */
+export const checkableGroupInputs = elem => {
+  if (!elem || isCheckableInput(elem) || typeof elem.querySelectorAll !== 'function') {
+    return null
+  }
+
+  const inputs = elem.querySelectorAll(CHECKABLE_INPUT_SELECTOR)
+
+  return inputs.length ? Array.from(inputs) : null
+}
+
+export const isCheckableGroup = elem => Boolean(checkableGroupInputs(elem))
+
+/**
+ * Value a condition compares against. Controls that can hold several values at once
+ * yield an array so that a single selection still matches an `equals` comparison.
+ * @param  {Element} elem
+ * @return {String|Array<String>|undefined}
+ */
+export const elementValue = elem => {
+  if (!elem) {
+    return undefined
+  }
+
+  const groupInputs = checkableGroupInputs(elem)
+  if (groupInputs) {
+    const checkedValues = groupInputs.filter(input => input.checked).map(input => input.value)
+
+    return groupInputs.every(input => input.type === 'radio') ? (checkedValues[0] ?? '') : checkedValues
+  }
+
+  if (tagName(elem) === 'select' && elem.multiple) {
+    return Array.from(elem.selectedOptions, option => option.value)
+  }
+
+  if (isCheckableInput(elem)) {
+    return elem.checked ? elem.value : ''
+  }
+
+  return elem.value
+}
+
+const isChecked = elem => {
+  const groupInputs = checkableGroupInputs(elem)
+
+  return groupInputs ? groupInputs.some(input => input.checked) : Boolean(elem?.checked)
+}
+
 export const propertyMap = {
   isChecked: elem => {
-    return elem.checked
+    return isChecked(elem)
   },
   isNotChecked: elem => {
-    return !elem.checked
+    return !isChecked(elem)
   },
-  value: elem => {
-    return elem.value
-  },
+  value: elementValue,
+  // "checked" is emitted by pre-v5 editors, where it stored the selected value rather than a boolean
+  checked: elementValue,
   isVisible: elem => {
     return isVisible(elem)
   },
@@ -62,11 +122,22 @@ export const createRemoveButton = () =>
     },
   })
 
+const equals = (source, target) =>
+  Array.isArray(source) ? source.some(value => isEqual(value, target)) : isEqual(source, target)
+
+const contains = (source, target) => {
+  if (source == null) {
+    return false
+  }
+
+  return Array.isArray(source) ? source.includes(target) : String(source).includes(target)
+}
+
 export const comparisonHandlers = {
-  equals: isEqual,
-  notEquals: (source, target) => !isEqual(source, target),
-  contains: (source, target) => source.includes(target),
-  notContains: (source, target) => !source.includes(target),
+  equals,
+  notEquals: (source, target) => !equals(source, target),
+  contains,
+  notContains: (source, target) => !contains(source, target),
 }
 
 export const comparisonMap = Object.entries(COMPARISON_OPERATORS).reduce((acc, [key, value]) => {

--- a/src/lib/js/renderer/index.js
+++ b/src/lib/js/renderer/index.js
@@ -7,6 +7,7 @@ import {
   baseId,
   comparisonMap,
   createRemoveButton,
+  isCheckableGroup,
   processOptions,
   propertyMap,
   RENDER_PREFIX,
@@ -299,7 +300,12 @@ export default class FormeoRenderer {
    * @return {Array} flattened array of conditions
    */
   handleComponentCondition = (component, ifRest, thenConditions) => {
-    if (component.length) {
+    if (!component) {
+      return
+    }
+
+    // a <select> has a native `length` (its option count), so only real collections may be spread
+    if (isNodeCollection(component)) {
       for (const elem of component) {
         this.handleComponentCondition(elem, ifRest, thenConditions)
       }
@@ -333,27 +339,33 @@ export default class FormeoRenderer {
 
   applyConditions = () => {
     for (const { conditions } of Object.values(this.components)) {
-      if (conditions) {
-        for (const condition of conditions) {
-          const { if: ifConditions, then: thenConditions } = condition
+      if (!conditions) {
+        continue
+      }
 
-          for (const ifCondition of ifConditions) {
-            const { source, target } = ifCondition
+      for (const condition of conditions) {
+        const { if: ifConditions = [], then: thenConditions = [] } = condition
 
-            if (isAddress(source)) {
-              const { component, options } = this.getComponent(source)
-              const sourceComponent = options || component
-              this.handleComponentCondition(sourceComponent, ifCondition, thenConditions)
-            }
-
-            if (isAddress(target)) {
-              const { component, options } = this.getComponent(target)
-              const targetComponent = options || component
-              this.handleComponentCondition(targetComponent, ifCondition, thenConditions)
-            }
+        for (const ifCondition of ifConditions) {
+          // a single unusable condition must never abort the render of the whole form
+          try {
+            this.applyCondition(ifCondition, thenConditions)
+          } catch (err) {
+            console.error('formeo: condition skipped', ifCondition, err)
           }
         }
       }
+    }
+  }
+
+  applyCondition = (ifCondition, thenConditions) => {
+    for (const address of [ifCondition.source, ifCondition.target]) {
+      if (!isAddress(address)) {
+        continue
+      }
+
+      const { component, options } = this.getComponent(address)
+      this.handleComponentCondition(options || component, ifCondition, thenConditions)
     }
   }
 
@@ -384,11 +396,16 @@ export default class FormeoRenderer {
   }
 
   getComponentProperty = (address, propertyName) => {
-    const { component, option } = this.getComponent(address)
+    const { component, option } = this.getComponent(address) || {}
 
     const elem = option || component
 
-    return propertyMap[propertyName]?.(elem) || elem[propertyName]
+    if (!elem) {
+      return undefined
+    }
+
+    // a mapped property must win even when it legitimately resolves to false or an empty value
+    return propertyMap[propertyName] ? propertyMap[propertyName](elem) : elem[propertyName]
   }
 
   getComponent = address => {
@@ -430,9 +447,17 @@ export default class FormeoRenderer {
   }
 }
 
+const isDomNode = value => Boolean(value) && typeof value.nodeType === 'number'
+
+const isNodeCollection = value => Boolean(value) && !isDomNode(value) && typeof value.length === 'number'
+
+const tagName = component => component.tagName?.toLowerCase()
+
 const listenTypeMap = [
-  ['input', c => ['textarea', 'text'].includes(c.type)],
-  ['change', c => ['select'].includes(c.tagName.toLowerCase()) || ['checkbox', 'radio'].includes(c.type)],
+  // option inputs sit inside the group wrapper the address resolves to; change events bubble up to it
+  ['change', component => isCheckableGroup(component)],
+  ['change', component => tagName(component) === 'select' || ['checkbox', 'radio'].includes(component.type)],
+  ['input', component => ['input', 'textarea'].includes(tagName(component))],
 ]
 
 const LISTEN_TYPE_MAP = component => {


### PR DESCRIPTION
Conditions only ever re-fired for text inputs and textareas. A <select> was mistaken for a NodeList (its native `length` is the option count), so listeners landed on its <option>s where no event ever arrives; radio and checkbox fields resolve to their group wrapper, which carries no value and matches no listener rule; and other input types were never listened to at all.

Value resolution now understands the rendered markup: a group yields the value of its checked members (an array for checkboxes, so a single selection still satisfies `equals`), a multi-select yields its selected values. `checked` is mapped as an alias of that resolution because forms saved by pre-v5 editors store a selected value under it rather than a boolean, and comparisons are array-aware and null-safe.

Applying a condition is wrapped per condition so one unusable entry — a dangling reference, a corrupted address — can no longer abort the render of the whole form. A mapped property also no longer falls back to the raw DOM property when it legitimately resolves to false.